### PR TITLE
fix: Address Copilot review feedback on RPi RC car PR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,10 @@ TWILIO_WHATSAPP_NUMBER=whatsapp:+14155238886
 # Secret token for authenticating API requests (generate with: openssl rand -hex 32)
 # OPENCASTOR_API_TOKEN=
 
-# Gateway bind address (use 0.0.0.0 to accept WhatsApp webhooks from the internet)
-OPENCASTOR_API_HOST=0.0.0.0
+# Gateway bind address
+# - 127.0.0.1 (default): only accept requests from the local machine (safer)
+# - 0.0.0.0: accept requests from any host (REQUIRES a strong OPENCASTOR_API_TOKEN)
+OPENCASTOR_API_HOST=127.0.0.1
 
 # Gateway port (default: 8000)
 OPENCASTOR_API_PORT=8000

--- a/castor/api.py
+++ b/castor/api.py
@@ -238,7 +238,7 @@ def _speak_reply(text: str):
 
         speaker = get_shared_speaker()
         if speaker is not None:
-            speaker.say(text[:120])
+            speaker.say(text)
     except Exception:
         pass
 
@@ -319,10 +319,12 @@ async def on_startup():
             state.driver = get_driver(state.config)
 
             # Initialize camera + speaker for live frames and TTS
-            import castor.main as _main_mod
+            from castor.main import set_shared_camera, set_shared_speaker
 
-            _main_mod._shared_camera = Camera(state.config)
-            _main_mod._shared_speaker = Speaker(state.config)
+            state.camera = Camera(state.config)
+            state.speaker = Speaker(state.config)
+            set_shared_camera(state.camera)
+            set_shared_speaker(state.speaker)
         except Exception as e:
             logger.warning(f"Config load error (gateway still operational): {e}")
     else:
@@ -344,6 +346,11 @@ async def on_shutdown():
     await _stop_channels()
     if state.driver:
         state.driver.close()
+    if hasattr(state, "camera") and state.camera:
+        state.camera.close()
+        state.camera = None
+    if hasattr(state, "speaker") and state.speaker:
+        state.speaker = None
     logger.info("OpenCastor Gateway shut down")
 
 

--- a/castor/providers/anthropic_provider.py
+++ b/castor/providers/anthropic_provider.py
@@ -14,7 +14,8 @@ class AnthropicProvider(BaseProvider):
     DEFAULT_MODEL = "claude-opus-4-6"
 
     def __init__(self, config):
-        # Apply default model before super().__init__ reads it
+        # Apply default model without mutating the caller's config dict
+        config = dict(config)
         if not config.get("model") or config.get("model") == "default-model":
             config["model"] = self.DEFAULT_MODEL
         super().__init__(config)
@@ -30,7 +31,7 @@ class AnthropicProvider(BaseProvider):
 
         # Build message content -- include image only if it has real data
         content = []
-        is_blank = image_bytes == b"\x00" * len(image_bytes)
+        is_blank = len(image_bytes) == 0 or all(b == 0 for b in image_bytes)
         if not is_blank and len(image_bytes) > 100:
             content.append(
                 {

--- a/castor/wizard.py
+++ b/castor/wizard.py
@@ -174,7 +174,7 @@ def choose_hardware():
     print("  [5] Freenove 4WD Car ($49)")
     print("  [6] SunFounder PiCar-X ($60)")
 
-    choice = input_default("Selection", "2")
+    choice = input_default("Selection", "1")
     return PRESETS.get(choice)
 
 

--- a/config/presets/rpi_rc_car.rcan.yaml
+++ b/config/presets/rpi_rc_car.rcan.yaml
@@ -18,7 +18,7 @@ agent:
   provider: "anthropic"
   model: "claude-opus-4-6"
   vision_enabled: true
-  latency_budget_ms: 3000
+  latency_budget_ms: 300
   safety_stop: true
 
 physics:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# The recommended stack: RPi + PCA9685 RC car + CSI camera + WhatsApp + Claude
+# RPi hardware: PCA9685 + CSI camera
 rpi = [
+    "adafruit-circuitpython-pca9685>=3.4.0",
+    "adafruit-circuitpython-motor>=3.4.0",
+    "picamera2>=0.3.17",
+]
+# Recommended RPi RC Car stack: hardware + WhatsApp
+rpi_rc_car = [
     "adafruit-circuitpython-pca9685>=3.4.0",
     "adafruit-circuitpython-motor>=3.4.0",
     "picamera2>=0.3.17",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,7 @@ echo "  \\___/| .__/ \\___|_| |_|\\___\\__,_/__/\\__\\___/_|"
 echo "       |_|"
 echo ""
 echo "OpenCastor Installer v0.1.0"
-echo "RPi RC Car + Claude Opus + WhatsApp Stack"
+echo "The Universal Runtime for Embodied AI"
 echo ""
 
 # 1. System Prep (includes CSI camera, audio, and I2C dependencies)
@@ -28,11 +28,29 @@ sudo apt-get install -y -qq \
 echo "[2/6] Enabling I2C and Camera interfaces..."
 if ! grep -q "^dtparam=i2c_arm=on" /boot/config.txt 2>/dev/null && \
    ! grep -q "^dtparam=i2c_arm=on" /boot/firmware/config.txt 2>/dev/null; then
-    sudo raspi-config nonint do_i2c 0 2>/dev/null || echo "  -> Enable I2C manually: sudo raspi-config"
+    sudo raspi-config nonint do_i2c 0 2>/dev/null || {
+        echo ""
+        echo -e "\033[31m  [WARNING] Failed to automatically enable I2C via raspi-config.\033[0m"
+        echo "           Your RC car hardware may not work until I2C is enabled."
+        echo ""
+        echo "           To enable I2C manually, run:"
+        echo "             sudo raspi-config -> Interface Options -> I2C -> Enable"
+        echo ""
+        read -p "  Press ENTER to continue installation anyway, or Ctrl+C to abort... " _
+    }
 fi
 if ! grep -q "^start_x=1" /boot/config.txt 2>/dev/null && \
    ! grep -q "camera_auto_detect=1" /boot/firmware/config.txt 2>/dev/null; then
-    sudo raspi-config nonint do_camera 0 2>/dev/null || echo "  -> Enable Camera manually: sudo raspi-config"
+    sudo raspi-config nonint do_camera 0 2>/dev/null || {
+        echo ""
+        echo -e "\033[31m  [WARNING] Failed to automatically enable Camera via raspi-config.\033[0m"
+        echo "           Your CSI camera may not work until the camera interface is enabled."
+        echo ""
+        echo "           To enable the Camera interface manually, run:"
+        echo "             sudo raspi-config -> Interface Options -> Legacy Camera -> Enable"
+        echo ""
+        read -p "  Press ENTER to continue installation anyway, or Ctrl+C to abort... " _
+    }
 fi
 
 # 3. Clone the Brain
@@ -46,14 +64,23 @@ else
     cd "$HOME/opencastor"
 fi
 
-# 4. Create Virtual Environment (--system-site-packages for picamera2)
+# 4. Create Virtual Environment
+# NOTE: --system-site-packages is required so that picamera2 (installed as a system
+# package via apt) is accessible inside the venv. picamera2 depends on libcamera
+# Python bindings which cannot be installed via pip.
 echo "[4/6] Setting up Python environment..."
 python3 -m venv --system-site-packages venv
 source venv/bin/activate
 
 # 5. Install Dependencies
-echo "[5/6] Installing Python packages (core + RPi + WhatsApp)..."
+echo "[5/6] Installing Python packages..."
 pip install --quiet -e ".[rpi]"
+
+# Note for Dynamixel users: dynamixel-sdk is no longer installed by default.
+# If your robot uses Dynamixel servos, install support with:
+#   pip install dynamixel-sdk
+# or:
+#   pip install -e ".[dynamixel]"
 
 # 6. Setup
 echo "[6/6] Setting up your robot..."
@@ -72,17 +99,19 @@ echo ""
 echo "================================================"
 echo "  OpenCastor installed successfully!"
 echo ""
-echo "  Quick Start (3 steps):"
-echo "    1. Edit .env and add your ANTHROPIC_API_KEY"
-echo "       and TWILIO_* credentials"
+echo "  Quick Start:"
+echo "    1. Edit .env and add your AI provider API key"
+echo "       (and messaging credentials if desired)"
 echo ""
 echo "    2. Start the gateway:"
-echo "       castor gateway --config config/presets/rpi_rc_car.rcan.yaml"
+echo "       castor gateway --config <your_config>.rcan.yaml"
 echo ""
-echo "    3. Send a WhatsApp message to your robot!"
-echo ""
-echo "  Other commands:"
-echo "    castor run --config config/presets/rpi_rc_car.rcan.yaml"
+echo "  Common commands:"
+echo "    castor run --config <config>.rcan.yaml"
+echo "    castor gateway --config <config>.rcan.yaml"
 echo "    castor status"
 echo "    castor dashboard"
+echo "    castor wizard     (re-run setup)"
+echo ""
+echo "  Dynamixel users: pip install dynamixel-sdk"
 echo "================================================"


### PR DESCRIPTION
- Add thread-safe locks for shared camera/speaker globals in main.py
- Use setter functions instead of direct module-level global mutation in api.py
- Add Camera and Speaker cleanup in gateway shutdown handler
- Improve Camera class docstring with config and fallback behavior docs
- Improve Speaker class docstring with config, threading model docs
- Add consistent error logging for Camera USB/OpenCV ImportError
- Check pygame mixer readiness before each TTS playback attempt
- Standardize text truncation at 200 chars in Speaker._speak only
- Fix inefficient blank image detection in anthropic_provider.py
- Avoid mutating caller's config dict in AnthropicProvider.__init__
- Add PCA9685 channel number validation (0-15 range)
- Add pulse width bounds clamping (500-2500us) to protect servos/ESCs
- Add 1s ESC arming delay after sending neutral throttle
- Fix British spelling 'recognises' -> 'recognizes'
- Revert latency_budget default from 3000ms to 200ms in main.py
- Lower rpi_rc_car preset latency_budget_ms from 3000 to 300ms
- Restore generic installer branding ("The Universal Runtime for Embodied AI")
- Make install.sh post-install instructions config-agnostic
- Add prominent warnings with manual instructions for I2C/Camera failures
- Document --system-site-packages rationale for picamera2/libcamera
- Add Dynamixel migration note in install.sh
- Revert wizard hardware default selection back to Custom
- Split pyproject.toml rpi extras: rpi (hardware only) + rpi_rc_car (+ WhatsApp)
- Default .env.example to 127.0.0.1 bind address for security

https://claude.ai/code/session_01LMC9RphQ1325Jfb8WY87fg