### PR TITLE
Add GitHub Actions workflow for Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,29 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'site/**'
+      - 'wrangler.toml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: "Deploy Site"
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./site --project-name=opencastor


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically deploy the site to Cloudflare Pages whenever changes are pushed to the main branch.

## Key Changes
- Added `.github/workflows/deploy-pages.yml` workflow file that:
  - Triggers on pushes to `main` branch when files in `site/` directory or `wrangler.toml` are modified
  - Supports manual workflow dispatch for on-demand deployments
  - Uses the official `cloudflare/wrangler-action@v3` to deploy to Cloudflare Pages
  - Deploys the `./site` directory to the `opencastor` project
  - Authenticates using Cloudflare API token and account ID stored as repository secrets

## Implementation Details
- The workflow runs on `ubuntu-latest` with minimal required permissions (read contents, write deployments)
- Deployment is triggered only when relevant files change, avoiding unnecessary deployments
- Uses GitHub Actions secrets for secure credential management (`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`)

https://claude.ai/code/session_0171eLjNm3UrfQMZPeWLgphG