### PR TITLE
Add secure-boot deployment guide, attestation tooling, and runtime safety posture reporting

### DIFF
--- a/castor/api.py
+++ b/castor/api.py
@@ -46,6 +46,7 @@ from castor.auth import (
     load_dotenv_if_available,
 )
 from castor.fs import CastorFS
+from castor.security_posture import publish_attestation
 
 logging.basicConfig(
     level=logging.INFO,
@@ -404,6 +405,9 @@ async def get_status(request: Request):
         "last_thought": state.last_thought,
         "audit_log_path": str(DEFAULT_AUDIT_LOG_PATH.expanduser()),
     }
+
+    if state.fs:
+        payload["security_posture"] = state.fs.ns.read("/proc/safety")
 
     # Provider health check — routed through active brain (respects fallback),
     # cached for 30 s to avoid flooding a quota-exhausted primary provider.
@@ -3046,6 +3050,12 @@ async def on_startup():
                 state.fs.boot(state.config)
                 set_shared_fs(state.fs)
             logger.info("Virtual Filesystem online")
+
+            # Security posture check (attestation token + degraded mode flag)
+            try:
+                publish_attestation(state.fs)
+            except Exception as _sec_exc:
+                logger.debug("Security posture check skipped: %s", _sec_exc)
 
             # Construct RURI from config
             try:

--- a/castor/fs/proc.py
+++ b/castor/fs/proc.py
@@ -49,6 +49,7 @@ class ProcFS:
         self.ns.mkdir("/proc/loop")
         self.ns.mkdir("/proc/brain")
         self.ns.mkdir("/proc/hw")
+        self.ns.mkdir("/proc/safety")
 
         self.ns.write("/proc/uptime", 0.0)
         self.ns.write("/proc/status", "booting")
@@ -84,6 +85,12 @@ class ProcFS:
         self.ns.write("/proc/hw/driver", "none")
         self.ns.write("/proc/hw/camera", "offline")
         self.ns.write("/proc/hw/speaker", "offline")
+
+        # Security posture state (updated by runtime boot checks)
+        self.ns.write("/proc/safety/mode", "unknown")
+        self.ns.write("/proc/safety/attestation", None)
+        self.ns.write("/proc/safety/attestation_status", "unknown")
+        self.ns.write("/proc/safety/attestation_token", None)
 
         # RCAN protocol state
         self.ns.mkdir("/proc/rcan")
@@ -180,5 +187,10 @@ class ProcFS:
                 "driver": self.ns.read("/proc/hw/driver"),
                 "camera": self.ns.read("/proc/hw/camera"),
                 "speaker": self.ns.read("/proc/hw/speaker"),
+            },
+            "safety": {
+                "mode": self.ns.read("/proc/safety/mode"),
+                "attestation_status": self.ns.read("/proc/safety/attestation_status"),
+                "attestation": self.ns.read("/proc/safety/attestation"),
             },
         }

--- a/castor/main.py
+++ b/castor/main.py
@@ -776,6 +776,19 @@ def main():
     set_shared_fs(fs)
     logger.info("Virtual Filesystem Online")
 
+    # 1d. SECURITY POSTURE CHECK (attestation / measured boot)
+    try:
+        from castor.security_posture import publish_attestation
+
+        posture = publish_attestation(fs)
+        if posture and posture.get("mode") == "degraded":
+            logger.warning(
+                "Security posture is degraded (%s)",
+                ",".join(posture.get("reasons", [])) or "attestation_unavailable",
+            )
+    except Exception as e:
+        logger.debug(f"Security posture check skipped: {e}")
+
     # 1c. CONSTRUCT RURI
     try:
         from castor.rcan.ruri import RURI

--- a/castor/security_posture.py
+++ b/castor/security_posture.py
@@ -1,0 +1,149 @@
+"""Security posture helpers for boot-time attestation checks.
+
+This module reads attestation data from either a kernel-exposed file,
+a local agent JSON file, or environment-provided token, then normalises
+it into a single structure that can be published into ``/proc/safety``
+and surfaced through API status endpoints.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("OpenCastor.Security")
+
+_DEFAULT_ATTESTATION_PATHS = (
+    "/proc/attestation/opencastor.json",
+    "/run/opencastor/attestation.json",
+)
+
+
+def _coerce_bool(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open() as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("Attestation payload must be a JSON object")
+    return payload
+
+
+def detect_attestation_status() -> Dict[str, Any]:
+    """Return normalized runtime security posture data.
+
+    Source precedence:
+      1) ``OPENCASTOR_ATTESTATION_PATH`` (JSON object file)
+      2) default local paths (first existing)
+      3) environment fallback values
+
+    The returned object is intentionally compact so it is safe to expose
+    in status APIs and lightweight virtual proc nodes.
+    """
+
+    source = "none"
+    payload: Dict[str, Any] = {}
+
+    configured_path = os.getenv("OPENCASTOR_ATTESTATION_PATH")
+    candidate_paths = [configured_path] if configured_path else []
+    candidate_paths.extend(_DEFAULT_ATTESTATION_PATHS)
+
+    for raw_path in candidate_paths:
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        if not path.exists():
+            continue
+        try:
+            payload = _load_json(path)
+            source = str(path)
+            break
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to parse attestation payload at %s: %s", path, exc)
+
+    # Environment fallback (for minimal profile setups)
+    env_token = os.getenv("OPENCASTOR_ATTESTATION_TOKEN")
+    env_verified = os.getenv("OPENCASTOR_ATTESTATION_VERIFIED")
+    env_profile = os.getenv("OPENCASTOR_SECURITY_PROFILE")
+
+    token = payload.get("token") or env_token
+    secure_boot = _coerce_bool(
+        payload.get("secure_boot"),
+        default=_coerce_bool(os.getenv("OPENCASTOR_SECURE_BOOT"), default=False),
+    )
+    measured_boot = _coerce_bool(
+        payload.get("measured_boot"),
+        default=_coerce_bool(os.getenv("OPENCASTOR_MEASURED_BOOT"), default=False),
+    )
+    update_chain = _coerce_bool(
+        payload.get("signed_updates"),
+        default=_coerce_bool(os.getenv("OPENCASTOR_SIGNED_UPDATES"), default=False),
+    )
+
+    if "verified" in payload:
+        verified = _coerce_bool(payload.get("verified"))
+    elif env_verified is not None:
+        verified = _coerce_bool(env_verified)
+    else:
+        verified = bool(secure_boot and measured_boot and update_chain)
+
+    profile = str(
+        payload.get("profile")
+        or env_profile
+        or ("secure" if verified else "minimum-viable")
+    )
+
+    mode = "enforced" if verified else "degraded"
+    reasons = []
+    if not secure_boot:
+        reasons.append("secure_boot_unverified")
+    if not measured_boot:
+        reasons.append("measured_boot_unavailable")
+    if not update_chain:
+        reasons.append("signed_update_chain_missing")
+
+    return {
+        "mode": mode,
+        "verified": verified,
+        "profile": profile,
+        "token_present": bool(token),
+        "token": token,
+        "source": source,
+        "claims": {
+            "secure_boot": secure_boot,
+            "measured_boot": measured_boot,
+            "signed_updates": update_chain,
+        },
+        "reasons": reasons,
+    }
+
+
+def publish_attestation(fs: Any) -> Optional[Dict[str, Any]]:
+    """Publish attestation state into ``/proc/safety`` nodes for a CastorFS instance."""
+
+    if fs is None:
+        return None
+
+    posture = detect_attestation_status()
+    try:
+        fs.ns.mkdir("/proc/safety")
+    except Exception:
+        pass
+
+    fs.ns.write("/proc/safety", posture)
+    fs.ns.write("/proc/safety/mode", posture["mode"])
+    fs.ns.write("/proc/safety/attestation", posture)
+    fs.ns.write("/proc/safety/attestation_status", "verified" if posture["verified"] else "degraded")
+    fs.ns.write("/proc/safety/attestation_token", posture.get("token"))
+    return posture

--- a/docs/security/deployment-guide.md
+++ b/docs/security/deployment-guide.md
@@ -1,0 +1,98 @@
+# OpenCastor OS Security Deployment Guide
+
+This guide provides a practical deployment baseline for hardened OpenCastor images on edge robots.
+
+## 1) Secure boot and verified kernel/initramfs
+
+### UEFI platforms (x86_64 / ARM server)
+1. Enroll your Platform Key (PK), Key Exchange Key (KEK), and db signing cert.
+2. Sign the bootloader, kernel, and initramfs with your trusted key.
+3. Configure the bootloader to reject unsigned kernels and unsigned initramfs.
+4. Verify with:
+   - `mokutil --sb-state`
+   - firmware event log / PCR[7] consistency checks.
+
+### Raspberry Pi / SBC equivalent path
+For Pi-class boards without full UEFI secure boot chain:
+1. Use EEPROM + signed `boot.img` workflow where available.
+2. Lock boot-order and disable USB mass-storage boot in production.
+3. Store public verification key in read-only boot partition.
+4. Verify kernel + initramfs hashes in early userspace before switching root.
+
+## 2) A/B updates with signed artifacts
+
+Use immutable A/B rootfs partitions (`rootfs_a`, `rootfs_b`) and a shared data partition:
+
+- Active slot boots read-only.
+- Update is written to inactive slot.
+- Signed manifest validates slot image + kernel + initramfs hashes.
+- Bootloader flips slot only after successful verification + health check.
+
+Generate a signed manifest using:
+
+```bash
+scripts/security/sign_ab_update.sh \
+  --slot-a out/rootfs_a.img \
+  --slot-b out/rootfs_b.img \
+  --kernel out/Image \
+  --initramfs out/initramfs.img \
+  --out out/update-manifest.json \
+  --key keys/update_signing.pem
+```
+
+Install the corresponding verification public key at `/etc/opencastor/update-trust.pub`.
+
+## 3) TPM measured boot and attestation token handoff
+
+If TPM is available:
+1. Measure firmware, bootloader, kernel, and initramfs into PCRs.
+2. Run a local attestation agent that validates PCR policy.
+3. Expose compact JSON attestation claims at:
+   - `/proc/attestation/opencastor.json` or
+   - `/run/opencastor/attestation.json`
+4. Optional: include a short-lived remote attestation token (`token`).
+
+OpenCastor reads that payload at startup and publishes it into `/proc/safety`.
+
+## 4) Runtime startup check integration (gateway + runtime)
+
+At startup, OpenCastor now:
+- reads attestation claims,
+- writes normalized posture into `/proc/safety`,
+- marks degraded mode when claims are incomplete.
+
+Surfaces include:
+- `/proc/safety` and `/proc/safety/attestation_status`
+- `GET /api/status` → `security_posture`
+
+You can point OpenCastor at a custom attestation file with:
+
+```bash
+export OPENCASTOR_ATTESTATION_PATH=/run/opencastor/attestation.json
+```
+
+## 5) Minimum viable secure profile (Raspberry Pi-class)
+
+When full TPM chain is unavailable, use **minimum-viable** profile:
+
+- Boot integrity:
+  - Signed boot artifacts where hardware supports it.
+  - Read-only boot partition after provisioning.
+- Update integrity:
+  - A/B partitioning with signed update manifest.
+  - Rollback on failed health check.
+- Runtime integrity:
+  - Generate local attestation claims via `scripts/security/collect_attestation.sh`.
+  - Pass optional cloud-issued token using `OPENCASTOR_ATTESTATION_TOKEN`.
+- Policy:
+  - Treat missing TPM measurement as degraded (not trusted-equal).
+  - Restrict high-risk actions when `/proc/safety/mode` is `degraded`.
+
+Example systemd pre-start step:
+
+```ini
+ExecStartPre=/opt/opencastor/scripts/security/collect_attestation.sh /run/opencastor/attestation.json
+Environment=OPENCASTOR_ATTESTATION_PATH=/run/opencastor/attestation.json
+```
+
+This profile is intentionally lightweight and achievable on constrained SBC deployments.

--- a/scripts/security/collect_attestation.sh
+++ b/scripts/security/collect_attestation.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_PATH="${1:-/run/opencastor/attestation.json}"
+PROFILE="${OPENCASTOR_SECURITY_PROFILE:-minimum-viable}"
+TOKEN="${OPENCASTOR_ATTESTATION_TOKEN:-}"
+
+secure_boot=false
+measured_boot=false
+signed_updates=false
+
+if [[ -d /sys/firmware/efi/efivars ]]; then
+  secure_boot=true
+fi
+
+if [[ -r /sys/kernel/security/tpm0/binary_bios_measurements || -r /sys/class/tpm/tpm0/device/pcrs ]]; then
+  measured_boot=true
+fi
+
+if [[ -f /etc/opencastor/update-trust.pub ]]; then
+  signed_updates=true
+fi
+
+verified=false
+if [[ "$secure_boot" == true && "$measured_boot" == true && "$signed_updates" == true ]]; then
+  verified=true
+fi
+
+mkdir -p "$(dirname "$OUT_PATH")"
+python - <<PY
+import json
+from pathlib import Path
+payload = {
+    "profile": "$PROFILE",
+    "secure_boot": "$secure_boot" == "true",
+    "measured_boot": "$measured_boot" == "true",
+    "signed_updates": "$signed_updates" == "true",
+    "verified": "$verified" == "true",
+}
+if "$TOKEN":
+    payload["token"] = "$TOKEN"
+Path("$OUT_PATH").write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
+echo "Attestation payload written: $OUT_PATH"

--- a/scripts/security/sign_ab_update.sh
+++ b/scripts/security/sign_ab_update.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a signed A/B update manifest for OpenCastor devices.
+#
+# Usage:
+#   scripts/security/sign_ab_update.sh \
+#     --slot-a rootfsA.img --slot-b rootfsB.img \
+#     --kernel Image --initramfs initramfs.img \
+#     --out dist/update-manifest.json --key keys/update_signing.pem
+
+SLOT_A=""
+SLOT_B=""
+KERNEL=""
+INITRAMFS=""
+OUT=""
+KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slot-a) SLOT_A="$2"; shift 2 ;;
+    --slot-b) SLOT_B="$2"; shift 2 ;;
+    --kernel) KERNEL="$2"; shift 2 ;;
+    --initramfs) INITRAMFS="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --key) KEY="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+for required in "$SLOT_A" "$SLOT_B" "$KERNEL" "$INITRAMFS" "$OUT" "$KEY"; do
+  [[ -n "$required" ]] || { echo "Missing required arguments" >&2; exit 1; }
+done
+
+hash_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+mkdir -p "$(dirname "$OUT")"
+
+TMP_MANIFEST="$(mktemp)"
+cat > "$TMP_MANIFEST" <<EOF
+{
+  "version": "$(date -u +%Y%m%d%H%M%S)",
+  "artifacts": {
+    "slot_a": {"path": "$SLOT_A", "sha256": "$(hash_file "$SLOT_A")"},
+    "slot_b": {"path": "$SLOT_B", "sha256": "$(hash_file "$SLOT_B")"},
+    "kernel": {"path": "$KERNEL", "sha256": "$(hash_file "$KERNEL")"},
+    "initramfs": {"path": "$INITRAMFS", "sha256": "$(hash_file "$INITRAMFS")"}
+  }
+}
+EOF
+
+SIGNATURE="$(openssl dgst -sha256 -sign "$KEY" "$TMP_MANIFEST" | base64 -w 0)"
+
+python - <<PY
+import json
+from pathlib import Path
+manifest = json.loads(Path("$TMP_MANIFEST").read_text())
+manifest["signature"] = {
+    "alg": "rsa-sha256",
+    "value_base64": "$SIGNATURE"
+}
+Path("$OUT").write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+rm -f "$TMP_MANIFEST"
+echo "Signed manifest written: $OUT"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -312,6 +312,14 @@ class TestStatusEndpoint:
         assert resp.json()["last_thought"]["raw_text"] == "hello"
 
 
+    def test_status_includes_security_posture_when_fs_available(self, client, api_mod):
+        api_mod.state.fs = _make_mock_fs()
+        api_mod.state.fs.ns.read.side_effect = lambda path: (
+            {"mode": "degraded", "verified": False} if path == "/proc/safety" else None
+        )
+        body = client.get("/api/status").json()
+        assert body["security_posture"]["mode"] == "degraded"
+
 # =====================================================================
 # POST /api/command
 # =====================================================================

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -1,0 +1,54 @@
+import json
+
+from castor.fs import CastorFS
+from castor.security_posture import detect_attestation_status, publish_attestation
+
+
+def test_detect_attestation_from_env(monkeypatch):
+    monkeypatch.setenv("OPENCASTOR_SECURE_BOOT", "1")
+    monkeypatch.setenv("OPENCASTOR_MEASURED_BOOT", "0")
+    monkeypatch.setenv("OPENCASTOR_SIGNED_UPDATES", "1")
+
+    result = detect_attestation_status()
+
+    assert result["verified"] is False
+    assert result["mode"] == "degraded"
+    assert "measured_boot_unavailable" in result["reasons"]
+
+
+def test_detect_attestation_from_file(tmp_path, monkeypatch):
+    payload_path = tmp_path / "attestation.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "secure_boot": True,
+                "measured_boot": True,
+                "signed_updates": True,
+                "verified": True,
+                "token": "abc123",
+                "profile": "secure",
+            }
+        )
+    )
+    monkeypatch.setenv("OPENCASTOR_ATTESTATION_PATH", str(payload_path))
+
+    result = detect_attestation_status()
+
+    assert result["verified"] is True
+    assert result["mode"] == "enforced"
+    assert result["token"] == "abc123"
+
+
+def test_publish_attestation_writes_proc_safety(monkeypatch):
+    monkeypatch.setenv("OPENCASTOR_SECURE_BOOT", "0")
+    monkeypatch.setenv("OPENCASTOR_SIGNED_UPDATES", "0")
+
+    fs = CastorFS()
+    fs.boot({"metadata": {"robot_name": "t"}, "agent": {}, "rcan_protocol": {}})
+
+    posture = publish_attestation(fs)
+
+    assert posture is not None
+    assert fs.ns.read("/proc/safety/mode") == "degraded"
+    assert fs.ns.read("/proc/safety/attestation_status") == "degraded"
+    assert isinstance(fs.ns.read("/proc/safety"), dict)


### PR DESCRIPTION
### Motivation
- Provide an operational path for verified boot, signed A/B updates, and TPM/measured-boot attestation so OpenCastor can run in a hardened posture on edge devices. 
- Surface runtime attestation/verification state to the runtime and API so operators and automation can detect and respond to degraded security.
- Offer a lightweight “minimum viable secure profile” for Raspberry Pi-class SBCs when a full TPM/UEFI chain is not available.

### Description
- Added `castor/security_posture.py` which normalizes attestation sources (attestation JSON file, environment fallbacks), computes `enforced` vs `degraded` mode, and exposes a `publish_attestation(fs)` helper that writes a compact posture into the VFS at `/proc/safety` and related nodes. 
- Extended the proc bootstrap and snapshot in `castor/fs/proc.py` to create `/proc/safety` nodes and include `safety` data in the `ProcFS.snapshot()` output. 
- Wired startup checks to invoke the attestation publish flow in both runtime and gateway startup paths (`castor/main.py` and `castor/api.py`), and had the gateway include `security_posture` in `GET /api/status` when the filesystem is available. 
- Added operational tooling under `scripts/security/`: `sign_ab_update.sh` to create a signed A/B update manifest and `collect_attestation.sh` to produce a local attestation JSON suitable for SBCs (minimum-viable profile). 
- Added a deployment guide at `docs/security/deployment-guide.md` describing secure boot, verified kernel/initramfs, A/B signed updates, TPM attestation handoff, runtime integration, and the Raspberry Pi-class minimum profile. 
- Added unit tests in `tests/test_security_posture.py` and a small API test addition to ensure `GET /api/status` surfaces `security_posture` when FS is present.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_security_posture.py` which passed (`3 passed`).
- Ran `python -m compileall castor/security_posture.py castor/main.py castor/api.py castor/fs/proc.py` which succeeded to verify import/compile sanity. 
- Performed shell checks and simple runs for scripts with `bash -n scripts/security/collect_attestation.sh scripts/security/sign_ab_update.sh` which reported no syntax errors, and executed `scripts/security/collect_attestation.sh /tmp/opencastor-attest.json` which produced a valid JSON payload. 
- Attempted a targeted combined test run (`PYTHONPATH=. pytest -q tests/test_security_posture.py tests/test_api_endpoints.py -k

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e092d2a80832ca326ef4d1dfa2ec4)