### PR TITLE
Add JWT secret provider abstraction with kid-based rotation

### DIFF
--- a/castor/api.py
+++ b/castor/api.py
@@ -46,6 +46,7 @@ from castor.auth import (
     load_dotenv_if_available,
 )
 from castor.fs import CastorFS
+from castor.secret_provider import get_jwt_secret_provider
 from castor.security_posture import publish_attestation
 
 logging.basicConfig(
@@ -242,12 +243,11 @@ async def verify_token(request: Request):
             pass  # Not a multi-user JWT; fall through
 
     # --- Layer 2: RCAN JWT (legacy JWT path) ---
-    jwt_secret = os.getenv("OPENCASTOR_JWT_SECRET")
-    if jwt_secret and raw_token:
+    if raw_token:
         try:
             from castor.rcan.jwt_auth import RCANTokenManager
 
-            mgr = RCANTokenManager(secret=jwt_secret, issuer=state.ruri or "")
+            mgr = RCANTokenManager(issuer=state.ruri or "")
             principal = mgr.verify(raw_token)
             request.state.principal = principal
             request.state.jwt_username = getattr(principal, "name", "unknown")
@@ -316,6 +316,11 @@ class UserLoginRequest(BaseModel):
     password: str
 
 
+class JWTKeyRotateRequest(BaseModel):
+    new_secret: Optional[str] = None
+    new_kid: Optional[str] = None
+
+
 @app.post("/auth/token")
 async def auth_token(req: UserLoginRequest):
     """Issue a JWT access token using username + password (multi-user auth).
@@ -369,6 +374,18 @@ async def auth_me(request: Request):
         return {"username": "api", "role": "admin", "auth_type": "static"}
 
     return {"username": "anonymous", "role": "viewer", "auth_type": "none"}
+
+
+@app.post("/auth/rotate-key", dependencies=[Depends(verify_token)])
+async def auth_rotate_key(req: JWTKeyRotateRequest, request: Request):
+    """Rotate JWT signing key and keep one previous verification key."""
+    _check_min_role(request, "admin")
+    bundle = get_jwt_secret_provider().rotate(new_secret=req.new_secret, new_kid=req.new_kid)
+    return {
+        "active_kid": bundle.active.kid,
+        "previous_kid": bundle.previous.kid if bundle.previous else None,
+        "source": bundle.source,
+    }
 
 
 def _maybe_wrap_rcan(payload: dict, request: Request) -> dict:
@@ -920,8 +937,8 @@ class TokenRequest(BaseModel):
 @app.post("/api/auth/token", dependencies=[Depends(verify_token)])
 async def issue_token(req: TokenRequest):
     """Issue a JWT token (requires OPENCASTOR_JWT_SECRET)."""
-    jwt_secret = os.getenv("OPENCASTOR_JWT_SECRET")
-    if not jwt_secret:
+    bundle = get_jwt_secret_provider().get_bundle()
+    if not bundle.active.secret:
         raise HTTPException(
             status_code=501,
             detail="JWT not configured. Set OPENCASTOR_JWT_SECRET.",
@@ -930,7 +947,7 @@ async def issue_token(req: TokenRequest):
         from castor.rcan.jwt_auth import RCANTokenManager
         from castor.rcan.rbac import RCANRole
 
-        mgr = RCANTokenManager(secret=jwt_secret, issuer=state.ruri or "")
+        mgr = RCANTokenManager(issuer=state.ruri or "")
         role = RCANRole[req.role.upper()]
         token = mgr.issue(
             subject=req.subject,
@@ -938,7 +955,7 @@ async def issue_token(req: TokenRequest):
             scopes=req.scopes,
             ttl_seconds=req.ttl_seconds,
         )
-        return {"token": token, "expires_in": req.ttl_seconds}
+        return {"token": token, "expires_in": req.ttl_seconds, "kid": bundle.active.kid}
     except KeyError as e:
         raise HTTPException(status_code=400, detail=f"Invalid role: {req.role}") from e
     except Exception as e:
@@ -3272,8 +3289,15 @@ async def on_startup():
     port = os.getenv("OPENCASTOR_API_PORT", "8000")
     logger.info(f"OpenCastor Gateway ready on {host}:{port}")
 
+    provider = get_jwt_secret_provider()
+    try:
+        provider.enforce_weak_source_policy()
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        raise
+
     # Warn if running without authentication
-    if not os.getenv("OPENCASTOR_API_TOKEN") and not os.getenv("OPENCASTOR_JWT_SECRET"):
+    if not os.getenv("OPENCASTOR_API_TOKEN") and not provider.get_bundle().active.secret:
         logger.warning(
             "Gateway running WITHOUT authentication. "
             "Set OPENCASTOR_API_TOKEN or OPENCASTOR_JWT_SECRET in .env for production."

--- a/castor/auth_jwt.py
+++ b/castor/auth_jwt.py
@@ -34,8 +34,9 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-import secrets
 from typing import Any, Dict, Optional, Tuple
+
+from castor.secret_provider import get_jwt_secret_provider
 
 logger = logging.getLogger("OpenCastor.AuthJWT")
 
@@ -75,22 +76,8 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _get_jwt_secret() -> str:
-    """Return the JWT secret, falling back to API token or random value."""
-    secret = os.getenv("JWT_SECRET") or os.getenv("OPENCASTOR_JWT_SECRET")
-    if secret:
-        return secret
-    api_token = os.getenv("OPENCASTOR_API_TOKEN")
-    if api_token:
-        return api_token
-    # Generate a random secret once per process and cache it
-    if not hasattr(_get_jwt_secret, "_cached"):
-        _get_jwt_secret._cached = secrets.token_hex(32)  # type: ignore[attr-defined]
-        logger.warning(
-            "No JWT_SECRET or OPENCASTOR_API_TOKEN configured — "
-            "using a per-process random secret.  Tokens will not survive restarts."
-        )
-    return _get_jwt_secret._cached  # type: ignore[attr-defined]
+def _get_secret_bundle():
+    return get_jwt_secret_provider().get_bundle()
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +152,9 @@ def create_token(
     if role not in ROLES:
         raise ValueError(f"Unknown role: {role!r}.  Valid roles: {list(ROLES)}")
 
-    secret = secret or _get_jwt_secret()
+    provided_secret = secret
+    key = _get_secret_bundle().active
+    secret = secret or key.secret
     now = datetime.datetime.now(datetime.timezone.utc)
     payload = {
         "sub": username,
@@ -173,7 +162,8 @@ def create_token(
         "iat": now,
         "exp": now + datetime.timedelta(hours=expires_h),
     }
-    return _pyjwt.encode(payload, secret, algorithm="HS256")
+    headers = {"kid": key.kid} if provided_secret is None else None
+    return _pyjwt.encode(payload, secret, algorithm="HS256", headers=headers)
 
 
 def decode_token(token: str, secret: Optional[str] = None) -> Dict[str, Any]:
@@ -194,8 +184,36 @@ def decode_token(token: str, secret: Optional[str] = None) -> Dict[str, Any]:
     if not HAS_JWT:
         raise ImportError("PyJWT is required for JWT auth.  Install with: pip install PyJWT>=2.8.0")
 
-    secret = secret or _get_jwt_secret()
-    return _pyjwt.decode(token, secret, algorithms=["HS256"])
+    if secret:
+        return _pyjwt.decode(token, secret, algorithms=["HS256"])
+
+    bundle = _get_secret_bundle()
+    key_candidates = [bundle.active]
+    if bundle.previous:
+        key_candidates.append(bundle.previous)
+
+    header_kid = None
+    try:
+        header_kid = _pyjwt.get_unverified_header(token).get("kid")
+    except Exception:
+        header_kid = None
+
+    if header_kid:
+        ordered = [k for k in key_candidates if k.kid == header_kid]
+        ordered.extend([k for k in key_candidates if k.kid != header_kid])
+        key_candidates = ordered
+
+    last_exc = None
+    for key in key_candidates:
+        try:
+            payload = _pyjwt.decode(token, key.secret, algorithms=["HS256"])
+            payload.setdefault("kid", key.kid)
+            return payload
+        except Exception as exc:
+            last_exc = exc
+    if last_exc:
+        raise last_exc
+    raise ValueError("No JWT key candidates available")
 
 
 def authenticate_user(

--- a/castor/cli.py
+++ b/castor/cli.py
@@ -226,12 +226,26 @@ def cmd_dashboard_tui(args) -> None:
 def cmd_token(args) -> None:
     """Issue a JWT token for RCAN API access."""
     from castor.auth import load_dotenv_if_available
+    from castor.secret_provider import get_jwt_secret_provider
 
     load_dotenv_if_available()
 
     import os
 
-    jwt_secret = os.getenv("OPENCASTOR_JWT_SECRET")
+    provider = get_jwt_secret_provider()
+    if args.rotate:
+        bundle = provider.rotate(new_secret=args.new_secret, new_kid=args.kid)
+        print("\n  JWT key rotated\n")
+        print(f"  active_kid:   {bundle.active.kid}")
+        print(f"  previous_kid: {bundle.previous.kid if bundle.previous else 'none'}\n")
+        return
+
+    if args.kid:
+        os.environ["OPENCASTOR_JWT_KID"] = args.kid
+        provider.invalidate()
+
+    bundle = provider.get_bundle()
+    jwt_secret = bundle.active.secret
     if not jwt_secret:
         print("Error: OPENCASTOR_JWT_SECRET is not set in environment or .env file.")
         print("Generate one with: openssl rand -hex 32")
@@ -253,7 +267,7 @@ def cmd_token(args) -> None:
             scopes=scopes,
             ttl_seconds=int(args.ttl) * 3600,
         )
-        print(f"\n  RCAN JWT Token (role={role.name}, ttl={args.ttl}h)\n")
+        print(f"\n  RCAN JWT Token (role={role.name}, ttl={args.ttl}h, kid={bundle.active.kid})\n")
         print(f"  {token}\n")
     except ImportError as exc:
         print("Error: PyJWT is not installed. Install with: pip install PyJWT")
@@ -2391,6 +2405,9 @@ def main() -> None:
     )
     p_token.add_argument("--ttl", default="24", help="Token lifetime in hours (default: 24)")
     p_token.add_argument("--subject", default=None, help="Principal name (default: cli-user)")
+    p_token.add_argument("--rotate", action="store_true", help="Rotate JWT signing key")
+    p_token.add_argument("--new-secret", default=None, help="Explicit replacement secret for --rotate")
+    p_token.add_argument("--kid", default=None, help="Key ID (kid) for issued or rotated key")
 
     # castor discover
     p_discover = sub.add_parser("discover", help="Discover RCAN peers on the local network")

--- a/castor/rcan/jwt_auth.py
+++ b/castor/rcan/jwt_auth.py
@@ -26,6 +26,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from castor.rcan.rbac import RCANPrincipal, RCANRole, Scope
+from castor.secret_provider import get_jwt_secret_provider
 
 logger = logging.getLogger("OpenCastor.RCAN.JWT")
 
@@ -53,17 +54,26 @@ class RCANTokenManager:
         issuer: Optional[str] = None,
         algorithm: str = "HS256",
     ):
-        self.secret = secret or os.getenv("OPENCASTOR_JWT_SECRET", "")
+        self._static_secret = secret
         self.issuer = issuer or "rcan://opencastor.unknown.00000000"
         self.algorithm = algorithm
 
-        if not self.secret:
+        if not self._static_secret and not get_jwt_secret_provider().get_bundle().active.secret:
             logger.debug("JWT secret not configured -- token operations will fail")
+
+    def _key_candidates(self):
+        if self._static_secret:
+            return [(os.getenv("OPENCASTOR_JWT_KID", "static"), self._static_secret)]
+        bundle = get_jwt_secret_provider().get_bundle()
+        candidates = [(bundle.active.kid, bundle.active.secret)]
+        if bundle.previous:
+            candidates.append((bundle.previous.kid, bundle.previous.secret))
+        return candidates
 
     @property
     def enabled(self) -> bool:
         """True if JWT is configured (secret is set and PyJWT available)."""
-        return bool(self.secret) and HAS_JWT
+        return bool(self._key_candidates()) and HAS_JWT
 
     def issue(
         self,
@@ -92,7 +102,8 @@ class RCANTokenManager:
         """
         if not HAS_JWT:
             raise RuntimeError("PyJWT is not installed. Install with: pip install PyJWT")
-        if not self.secret:
+        key_candidates = self._key_candidates()
+        if not key_candidates:
             raise RuntimeError("OPENCASTOR_JWT_SECRET is not configured")
 
         now = time.time()
@@ -110,7 +121,8 @@ class RCANTokenManager:
             "exp": int(now + ttl_seconds),
         }
 
-        token = jwt.encode(claims, self.secret, algorithm=self.algorithm)
+        active_kid, active_secret = key_candidates[0]
+        token = jwt.encode(claims, active_secret, algorithm=self.algorithm, headers={"kid": active_kid})
         logger.info("Issued JWT for %s (role=%s, ttl=%ds)", subject, role.name, ttl_seconds)
         return token
 
@@ -130,15 +142,36 @@ class RCANTokenManager:
         """
         if not HAS_JWT:
             raise RuntimeError("PyJWT is not installed")
-        if not self.secret:
+        key_candidates = self._key_candidates()
+        if not key_candidates:
             raise RuntimeError("OPENCASTOR_JWT_SECRET is not configured")
 
-        claims = jwt.decode(
-            token,
-            self.secret,
-            algorithms=[self.algorithm],
-            options={"verify_aud": False},
-        )
+        header_kid = None
+        try:
+            header_kid = jwt.get_unverified_header(token).get("kid")
+        except Exception:
+            header_kid = None
+        if header_kid:
+            key_candidates = [k for k in key_candidates if k[0] == header_kid] + [
+                k for k in key_candidates if k[0] != header_kid
+            ]
+
+        claims = None
+        last_exc = None
+        for kid, key_secret in key_candidates:
+            try:
+                claims = jwt.decode(
+                    token,
+                    key_secret,
+                    algorithms=[self.algorithm],
+                    options={"verify_aud": False},
+                )
+                claims.setdefault("kid", kid)
+                break
+            except Exception as exc:
+                last_exc = exc
+        if claims is None and last_exc is not None:
+            raise last_exc
 
         role = RCANRole[claims.get("role", "GUEST")]
         scopes = Scope.from_strings(claims.get("scope", []))
@@ -158,9 +191,12 @@ class RCANTokenManager:
         """Decode a JWT token without verification (for inspection only)."""
         if not HAS_JWT:
             raise RuntimeError("PyJWT is not installed")
+        key_candidates = self._key_candidates()
+        if not key_candidates:
+            raise RuntimeError("OPENCASTOR_JWT_SECRET is not configured")
         return jwt.decode(
             token,
-            self.secret,
+            key_candidates[0][1],
             algorithms=[self.algorithm],
             options={"verify_exp": False, "verify_aud": False},
         )

--- a/castor/secret_provider.py
+++ b/castor/secret_provider.py
@@ -1,0 +1,223 @@
+"""Secret provider abstraction for JWT signing and verification."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("OpenCastor.Secrets")
+
+
+@dataclass
+class JWTKeyMaterial:
+    kid: str
+    secret: str
+
+
+@dataclass
+class JWTSecretBundle:
+    active: JWTKeyMaterial
+    previous: Optional[JWTKeyMaterial]
+    source: str
+
+    @property
+    def weak_source(self) -> bool:
+        return self.source == "env"
+
+
+class JWTSecretProvider:
+    """Load JWT keys from preferred secure sources with env fallback."""
+
+    def __init__(self) -> None:
+        self._cached_bundle: Optional[JWTSecretBundle] = None
+
+    def get_bundle(self) -> JWTSecretBundle:
+        if self._cached_bundle is None:
+            self._cached_bundle = self._load_bundle()
+        return self._cached_bundle
+
+    def invalidate(self) -> None:
+        self._cached_bundle = None
+
+    def rotate(self, *, new_secret: Optional[str] = None, new_kid: Optional[str] = None) -> JWTSecretBundle:
+        current = self.get_bundle()
+        active = current.active
+        replacement = JWTKeyMaterial(
+            kid=new_kid or f"k-{secrets.token_hex(4)}",
+            secret=new_secret or secrets.token_hex(32),
+        )
+        rotated = {
+            "active": {"kid": replacement.kid, "secret": replacement.secret},
+            "previous": {"kid": active.kid, "secret": active.secret},
+        }
+        rotation_path = Path(
+            os.getenv("OPENCASTOR_JWT_ROTATION_FILE", "~/.opencastor/jwt-keys.json")
+        ).expanduser()
+        rotation_path.parent.mkdir(parents=True, exist_ok=True)
+        rotation_path.write_text(json.dumps(rotated, indent=2), encoding="utf-8")
+        os.environ["OPENCASTOR_JWT_SECRETS_FILE"] = str(rotation_path)
+        self.invalidate()
+        bundle = self.get_bundle()
+        logger.info("Rotated JWT signing key. active_kid=%s previous_kid=%s", bundle.active.kid, bundle.previous.kid if bundle.previous else None)
+        return bundle
+
+    def enforce_weak_source_policy(self) -> None:
+        bundle = self.get_bundle()
+        if not bundle.weak_source:
+            return
+
+        env_profile = (
+            os.getenv("OPENCASTOR_ENV")
+            or os.getenv("OPENCASTOR_PROFILE")
+            or os.getenv("OPENCASTOR_SECURITY_PROFILE")
+            or ""
+        ).strip().lower()
+        is_prod = env_profile in {"prod", "production", "secure", "hardened"}
+        if not is_prod:
+            return
+
+        policy = os.getenv("OPENCASTOR_JWT_WEAK_SOURCE_POLICY", "warn").strip().lower()
+        message = (
+            "JWT secrets loaded from plain environment variables in production profile. "
+            "Prefer kernel keyring/systemd credentials/vault-mounted file sources."
+        )
+        if policy == "error":
+            raise RuntimeError(message)
+        logger.warning(message)
+
+    def _load_bundle(self) -> JWTSecretBundle:
+        for loader in (
+            self._from_keyring,
+            self._from_systemd_credentials,
+            self._from_vault_file,
+            self._from_env,
+        ):
+            bundle = loader()
+            if bundle is not None:
+                return bundle
+
+        fallback = secrets.token_hex(32)
+        logger.warning("No JWT secret configured; using process-local random secret")
+        return JWTSecretBundle(
+            active=JWTKeyMaterial(kid="ephemeral", secret=fallback),
+            previous=None,
+            source="ephemeral",
+        )
+
+    def _from_keyring(self) -> Optional[JWTSecretBundle]:
+        key_id = os.getenv("OPENCASTOR_JWT_SECRET_KEYRING_ID")
+        if not key_id:
+            return None
+        try:
+            out = subprocess.check_output(["keyctl", "pipe", key_id], text=True).strip()
+            if not out:
+                return None
+            return JWTSecretBundle(
+                active=JWTKeyMaterial(
+                    kid=os.getenv("OPENCASTOR_JWT_KID", "keyring-active"),
+                    secret=out,
+                ),
+                previous=None,
+                source="keyring",
+            )
+        except Exception as exc:
+            logger.warning("Failed loading JWT secret from keyring id=%s: %s", key_id, exc)
+            return None
+
+    def _from_systemd_credentials(self) -> Optional[JWTSecretBundle]:
+        credential_name = os.getenv("OPENCASTOR_JWT_SECRET_CREDENTIAL", "opencastor_jwt_secret")
+        search_paths = []
+        cred_dir = os.getenv("CREDENTIALS_DIRECTORY")
+        if cred_dir:
+            search_paths.append(Path(cred_dir) / credential_name)
+        search_paths.extend(
+            [
+                Path(f"/run/credentials/{credential_name}"),
+                Path(f"/run/secrets/{credential_name}"),
+            ]
+        )
+        for path in search_paths:
+            if path.exists():
+                secret = path.read_text(encoding="utf-8").strip()
+                if secret:
+                    return JWTSecretBundle(
+                        active=JWTKeyMaterial(
+                            kid=os.getenv("OPENCASTOR_JWT_KID", "systemd-active"),
+                            secret=secret,
+                        ),
+                        previous=None,
+                        source="systemd",
+                    )
+        return None
+
+    def _from_vault_file(self) -> Optional[JWTSecretBundle]:
+        configured = os.getenv("OPENCASTOR_JWT_SECRETS_FILE") or os.getenv("OPENCASTOR_JWT_SECRET_FILE")
+        paths = [configured] if configured else []
+        paths.extend([
+            os.getenv("OPENCASTOR_JWT_ROTATION_FILE"),
+            "/vault/secrets/opencastor-jwt.json",
+            "/vault/secrets/opencastor_jwt_secret",
+        ])
+        for raw in paths:
+            if not raw:
+                continue
+            path = Path(raw).expanduser()
+            if not path.exists():
+                continue
+            raw_text = path.read_text(encoding="utf-8").strip()
+            if not raw_text:
+                continue
+            try:
+                payload = json.loads(raw_text)
+                active_raw = payload.get("active", {})
+                prev_raw = payload.get("previous")
+                active = JWTKeyMaterial(
+                    kid=str(active_raw.get("kid") or "vault-active"),
+                    secret=str(active_raw.get("secret") or ""),
+                )
+                if not active.secret:
+                    continue
+                previous = None
+                if isinstance(prev_raw, dict) and prev_raw.get("secret"):
+                    previous = JWTKeyMaterial(
+                        kid=str(prev_raw.get("kid") or "vault-previous"),
+                        secret=str(prev_raw.get("secret")),
+                    )
+                return JWTSecretBundle(active=active, previous=previous, source=f"file:{path}")
+            except json.JSONDecodeError:
+                return JWTSecretBundle(
+                    active=JWTKeyMaterial(kid=os.getenv("OPENCASTOR_JWT_KID", "file-active"), secret=raw_text),
+                    previous=None,
+                    source=f"file:{path}",
+                )
+        return None
+
+    def _from_env(self) -> Optional[JWTSecretBundle]:
+        active_secret = os.getenv("JWT_SECRET") or os.getenv("OPENCASTOR_JWT_SECRET") or os.getenv("OPENCASTOR_API_TOKEN")
+        if not active_secret:
+            return None
+        active = JWTKeyMaterial(
+            kid=os.getenv("OPENCASTOR_JWT_KID") or os.getenv("JWT_KID") or "env-active",
+            secret=active_secret,
+        )
+        prev_secret = os.getenv("OPENCASTOR_JWT_PREVIOUS_SECRET")
+        previous = None
+        if prev_secret:
+            previous = JWTKeyMaterial(
+                kid=os.getenv("OPENCASTOR_JWT_PREVIOUS_KID", "env-previous"),
+                secret=prev_secret,
+            )
+        return JWTSecretBundle(active=active, previous=previous, source="env")
+
+
+_provider = JWTSecretProvider()
+
+
+def get_jwt_secret_provider() -> JWTSecretProvider:
+    return _provider

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -84,6 +84,28 @@ class TestCreateDecodeToken:
         with pytest.raises(jwt.exceptions.DecodeError):
             decode_token("this.is.not.a.valid.jwt", secret="test-secret-xyz")
 
+    def test_decode_accepts_previous_key_with_kid(self):
+        """decode_token should accept previous secret during rotation window."""
+        from castor.auth_jwt import create_token, decode_token
+        from castor.secret_provider import get_jwt_secret_provider
+
+        provider = get_jwt_secret_provider()
+        with patch.dict(
+            os.environ,
+            {
+                "JWT_SECRET": "active-secret",
+                "OPENCASTOR_JWT_KID": "kid-active",
+                "OPENCASTOR_JWT_PREVIOUS_SECRET": "old-secret",
+                "OPENCASTOR_JWT_PREVIOUS_KID": "kid-old",
+            },
+            clear=False,
+        ):
+            provider.invalidate()
+            old_token = create_token("legacy", "viewer", secret="old-secret")
+            payload = decode_token(old_token)
+            assert payload["sub"] == "legacy"
+            assert payload["kid"] == "kid-old"
+
 
 class TestAPIEndpoints:
     """Tests for the FastAPI /auth/token and /auth/me endpoints."""
@@ -183,3 +205,16 @@ class TestAPIEndpoints:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert cmd_resp.status_code != 403
+
+    def test_rotate_key_endpoint_requires_auth_and_rotates(self, client):
+        login = client.post("/auth/token", json={"username": "admin", "password": "adminpass"})
+        token = login.json()["access_token"]
+        resp = client.post(
+            "/auth/rotate-key",
+            json={"new_secret": "next-secret", "new_kid": "next-kid"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["active_kid"] == "next-kid"
+        assert body["previous_kid"] is not None

--- a/tests/test_rcan_jwt_auth.py
+++ b/tests/test_rcan_jwt_auth.py
@@ -1,0 +1,32 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("jwt", reason="PyJWT not installed")
+
+
+def test_rcan_token_manager_uses_kid_and_previous_key():
+    from castor.rcan.jwt_auth import RCANTokenManager
+    from castor.rcan.rbac import RCANRole
+    from castor.secret_provider import get_jwt_secret_provider
+
+    provider = get_jwt_secret_provider()
+    with patch.dict(
+        os.environ,
+        {
+            "OPENCASTOR_JWT_SECRET": "active-secret",
+            "OPENCASTOR_JWT_KID": "active-kid",
+            "OPENCASTOR_JWT_PREVIOUS_SECRET": "old-secret",
+            "OPENCASTOR_JWT_PREVIOUS_KID": "old-kid",
+        },
+        clear=False,
+    ):
+        provider.invalidate()
+        mgr = RCANTokenManager(issuer="rcan://unit.test.00000001")
+        old_mgr = RCANTokenManager(secret="old-secret", issuer="rcan://unit.test.00000001")
+
+        old_token = old_mgr.issue("legacy-user", role=RCANRole.USER)
+        principal = mgr.verify(old_token)
+
+        assert principal.name == "legacy-user"


### PR DESCRIPTION
### Motivation

- Centralise JWT key handling behind a secure provider so tokens can be signed/verified from stronger secret sources (keyring/systemd/vault-file) with an env fallback.
- Support `kid` headers and keep an active+previous verification window to enable seamless key rotation without breaking existing tokens.
- Expose rotation controls via CLI and admin API and enforce a startup policy when secrets are sourced from plain environment variables in production profiles.

### Description

- Added a new secret provider module `castor.secret_provider` that implements a priority chain for JWT key material: kernel keyring -> systemd credentials/secrets -> vault/file mounts -> environment fallback, and returns an `active` + optional `previous` key bundle with `kid` metadata.
- Integrated the provider into `castor/auth_jwt.py`: token issuance uses the provider key and emits `kid` headers when appropriate, and token verification attempts the `active` and `previous` keys (preferring a matching `kid`).
- Updated `castor/rcan/jwt_auth.py` to use the provider for issuance and verification, include `kid` in issued tokens, and support dual-key verification order and `kid`-aware checks.
- Added an admin API endpoint `POST /auth/rotate-key` and surfaced `kid` in `/api/auth/token` responses, and wired `verify_token` to use the provider-backed `RCANTokenManager` path.
- Extended `castor` CLI `token` command with `--rotate`, `--new-secret`, and `--kid` options for on-disk rotation and CLI-driven rotation; CLI now shows the active `kid` when issuing tokens.
- Implemented a weak-source startup policy via `JWTSecretProvider.enforce_weak_source_policy()` that warns or errors when secrets come from plain env vars while running in production/security profiles (`OPENCASTOR_JWT_WEAK_SOURCE_POLICY=warn|error`).
- Added/updated tests: `tests/test_rcan_jwt_auth.py` (new) and extended `tests/test_auth_jwt.py` to exercise previous-key + `kid` behavior and the rotation endpoint.

### Testing

- Ran a quick syntax/compile check with `python -m py_compile` against modified modules and tests; compilation passed.
- Ran the targeted JWT unit tests with `pytest` for the added/updated tests (`tests/test_auth_jwt.py`, `tests/test_rcan_jwt_auth.py`); these tests are present and executed but were skipped in this environment because `PyJWT` is not installed (skipped tests reported by `pytest`).
- All local static checks (compilation) succeeded; JWT runtime tests are gated on `PyJWT` being available and will exercise `kid`/rotation behavior when run in an environment with `PyJWT` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0c8ff344832cb6a8eff439168d90)