### PR TITLE
Add deployable MAC/seccomp profiles and integrate hardening diagnostics

### DIFF
--- a/castor/daemon.py
+++ b/castor/daemon.py
@@ -22,6 +22,7 @@ import yaml
 
 SERVICE_NAME = "castor-gateway"
 SERVICE_PATH = Path(f"/etc/systemd/system/{SERVICE_NAME}.service")
+SECURITY_INSTALL_PATH = Path("/etc/opencastor/security")
 
 
 # ── Service file generation ────────────────────────────────────────────────────
@@ -91,6 +92,10 @@ DeviceAllow=/dev/spidev0.1 rw
 DeviceAllow=/dev/gpiochip0 rw
 DeviceAllow=/dev/video0 rw
 ReadWritePaths={runtime_dir}
+AppArmorProfile=opencastor-gateway
+SystemCallFilter=@system-service @network-io @file-system @io-event
+SystemCallFilter=~@mount @swap @clock @cpu-emulation @obsolete
+SystemCallErrorNumber=EPERM
 """
 
     return f"""\
@@ -187,6 +192,10 @@ SystemCallArchitectures=native
 RestrictAddressFamilies=AF_UNIX
 PrivateNetwork=true
 DevicePolicy=closed
+AppArmorProfile=opencastor-driver
+SystemCallFilter=@basic-io @file-system @signal
+SystemCallFilter=~@mount @network-io @privileged @resources @raw-io @debug
+SystemCallErrorNumber=EPERM
 {device_allows}
 
 [Install]
@@ -228,6 +237,7 @@ def enable_daemon(
     Returns a status dict with ``ok``, ``message``, and ``service_path``.
     """
     service_content = generate_service_file(config_path, user, venv_path, working_dir)
+    _install_security_profiles()
 
     try:
         SERVICE_PATH.write_text(service_content)
@@ -324,8 +334,54 @@ def daemon_logs(lines: int = 50) -> str:
     return result.stdout.decode()
 
 
+def daemon_security_status() -> dict:
+    """Return whether MAC/seccomp protections are present and active."""
+    status = {
+        "profiles_installed": SECURITY_INSTALL_PATH.exists(),
+        "apparmor_profile": None,
+        "seccomp_mode": None,
+        "enabled_in_unit": False,
+    }
+
+    if SERVICE_PATH.exists():
+        unit_text = SERVICE_PATH.read_text(encoding="utf-8")
+        status["enabled_in_unit"] = (
+            "AppArmorProfile=opencastor-gateway" in unit_text
+            and "SystemCallFilter=" in unit_text
+        )
+
+    service = daemon_status()
+    pid = service.get("pid") if isinstance(service, dict) else None
+    if not pid:
+        return status
+
+    attr_current = Path(f"/proc/{pid}/attr/current")
+    proc_status = Path(f"/proc/{pid}/status")
+
+    if attr_current.exists():
+        status["apparmor_profile"] = attr_current.read_text(encoding="utf-8").strip()
+
+    if proc_status.exists():
+        for line in proc_status.read_text(encoding="utf-8").splitlines():
+            if line.startswith("Seccomp:"):
+                status["seccomp_mode"] = line.split(":", 1)[1].strip()
+                break
+
+    return status
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
 def _run(cmd: list[str], check: bool = False, **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, check=check, **kwargs)
+
+
+def _install_security_profiles() -> None:
+    script = Path(__file__).resolve().parent.parent / "deploy" / "security" / "install_profiles.sh"
+    if not script.exists():
+        return
+    runner = ["bash", str(script)]
+    if os.geteuid() != 0:
+        runner = ["sudo", *runner]
+    _run(runner, check=False)

--- a/castor/doctor.py
+++ b/castor/doctor.py
@@ -13,6 +13,28 @@ import os
 import sys
 
 
+def check_mac_seccomp():
+    """Check whether daemon MAC and seccomp hardening are active."""
+    try:
+        from castor.daemon import daemon_security_status
+
+        status = daemon_security_status()
+    except Exception as exc:
+        return False, "MAC/seccomp", f"status unavailable: {exc}"
+
+    if not status.get("profiles_installed"):
+        return False, "MAC/seccomp", "profiles not installed (/etc/opencastor/security missing)"
+
+    apparmor = status.get("apparmor_profile") or "n/a"
+    seccomp = status.get("seccomp_mode") or "n/a"
+    in_unit = status.get("enabled_in_unit", False)
+    seccomp_active = seccomp == "2"
+    apparmor_active = apparmor not in {"n/a", "unconfined"}
+    ok = bool(in_unit and seccomp_active and apparmor_active)
+    detail = f"unit={'on' if in_unit else 'off'}, apparmor={apparmor}, seccomp={seccomp}"
+    return ok, "MAC/seccomp", detail
+
+
 def check_python_version():
     """Check Python >= 3.10."""
     ok = sys.version_info >= (3, 10)
@@ -194,6 +216,7 @@ def run_all_checks(config_path=None):
 
     results.extend(check_hardware_sdks())
     results.append(check_camera())
+    results.append(check_mac_seccomp())
 
     return results
 

--- a/deploy/security/README.md
+++ b/deploy/security/README.md
@@ -1,0 +1,15 @@
+# OpenCastor MAC / seccomp deployment artifacts
+
+This directory contains deployable Linux runtime hardening profiles:
+
+- `apparmor/opencastor-gateway` - gateway confinement profile.
+- `apparmor/opencastor-driver` - stricter isolated driver confinement profile.
+- `seccomp/gateway-seccomp.json` - gateway syscall allow-list policy.
+- `seccomp/driver-strict-seccomp.json` - isolated driver syscall allow-list.
+- `install_profiles.sh` - installer/activator for `/etc/opencastor/security`.
+
+Install them on a target host with:
+
+```bash
+bash deploy/security/install_profiles.sh
+```

--- a/deploy/security/apparmor/opencastor-driver
+++ b/deploy/security/apparmor/opencastor-driver
@@ -1,0 +1,30 @@
+#include <tunables/global>
+
+profile opencastor-driver flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/python>
+
+  /usr/bin/python3 ixr,
+
+  /opt/opencastor/** r,
+  /etc/opencastor/** r,
+  /var/lib/opencastor/drivers/** rwk,
+  /run/opencastor/** rwk,
+
+  /dev/null rw,
+  /dev/zero rw,
+  /dev/random rw,
+  /dev/urandom rw,
+  /dev/ttyUSB[0-9]* rw,
+  /dev/ttyACM[0-9]* rw,
+  /dev/i2c-[0-9]* rw,
+  /dev/gpiochip[0-9]* rw,
+
+  # Drivers run offline by default.
+  deny network,
+
+  # Deny privilege escalation and shells.
+  deny /bin/sh x,
+  deny /bin/bash x,
+  deny /usr/bin/sudo x,
+}

--- a/deploy/security/apparmor/opencastor-gateway
+++ b/deploy/security/apparmor/opencastor-gateway
@@ -1,0 +1,45 @@
+#include <tunables/global>
+
+profile opencastor-gateway flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/python>
+
+  # Executables allowed for process transitions.
+  /usr/bin/python3 ixr,
+  /usr/bin/env ixr,
+  /bin/sh ixr,
+
+  # OpenCastor install + runtime paths.
+  /opt/opencastor/** r,
+  /etc/opencastor/** r,
+  /var/lib/opencastor/** rwk,
+  /run/opencastor/** rwk,
+  owner @{HOME}/opencastor/** rwk,
+
+  # Required device nodes.
+  /dev/null rw,
+  /dev/zero rw,
+  /dev/full rw,
+  /dev/random rw,
+  /dev/urandom rw,
+  /dev/tty rw,
+  /dev/ttyAMA0 rw,
+  /dev/ttyS0 rw,
+  /dev/ttyUSB[0-9]* rw,
+  /dev/ttyACM[0-9]* rw,
+  /dev/i2c-[0-9]* rw,
+  /dev/spidev[0-9]*.[0-9]* rw,
+  /dev/gpiochip[0-9]* rw,
+  /dev/video[0-9]* rw,
+
+  # Networking and proc reads for telemetry/status.
+  network inet stream,
+  network inet6 stream,
+  /proc/** r,
+  /sys/devices/** r,
+
+  # Block shell escapes + arbitrary exec transitions.
+  deny /bin/bash x,
+  deny /usr/bin/sudo x,
+  deny /usr/bin/ssh x,
+}

--- a/deploy/security/install_profiles.sh
+++ b/deploy/security/install_profiles.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APPARMOR_DIR="$ROOT_DIR/apparmor"
+SECCOMP_DIR="$ROOT_DIR/seccomp"
+TARGET_ETC="/etc/opencastor/security"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "[WARN] MAC/seccomp profiles are only installed on Linux hosts."
+  exit 0
+fi
+
+SUDO=""
+if [[ "${EUID}" -ne 0 ]]; then
+  SUDO="sudo"
+fi
+
+$SUDO mkdir -p "$TARGET_ETC/apparmor" "$TARGET_ETC/seccomp"
+$SUDO cp "$APPARMOR_DIR/opencastor-gateway" "$TARGET_ETC/apparmor/opencastor-gateway"
+$SUDO cp "$APPARMOR_DIR/opencastor-driver" "$TARGET_ETC/apparmor/opencastor-driver"
+$SUDO cp "$SECCOMP_DIR/gateway-seccomp.json" "$TARGET_ETC/seccomp/gateway-seccomp.json"
+$SUDO cp "$SECCOMP_DIR/driver-strict-seccomp.json" "$TARGET_ETC/seccomp/driver-strict-seccomp.json"
+
+if command -v apparmor_parser >/dev/null 2>&1; then
+  $SUDO apparmor_parser -r "$TARGET_ETC/apparmor/opencastor-gateway" || true
+  $SUDO apparmor_parser -r "$TARGET_ETC/apparmor/opencastor-driver" || true
+fi
+
+echo "Installed MAC/seccomp artifacts to $TARGET_ETC"

--- a/deploy/security/seccomp/driver-strict-seccomp.json
+++ b/deploy/security/seccomp/driver-strict-seccomp.json
@@ -1,0 +1,19 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_AARCH64",
+    "SCMP_ARCH_ARM"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "read", "write", "open", "openat", "close", "fstat", "newfstatat", "statx", "lseek",
+        "mmap", "mprotect", "munmap", "brk", "rt_sigaction", "rt_sigprocmask", "ioctl", "access",
+        "clock_gettime", "nanosleep", "futex", "set_robust_list", "prctl", "getrandom", "getpid",
+        "gettid", "exit", "exit_group", "poll", "ppoll", "select", "pselect6"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}

--- a/deploy/security/seccomp/gateway-seccomp.json
+++ b/deploy/security/seccomp/gateway-seccomp.json
@@ -1,0 +1,23 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_AARCH64",
+    "SCMP_ARCH_ARM"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "read", "write", "open", "openat", "close", "fstat", "newfstatat", "statx",
+        "lseek", "mmap", "mprotect", "munmap", "brk", "rt_sigaction", "rt_sigprocmask",
+        "ioctl", "access", "pipe", "pipe2", "select", "pselect6", "poll", "ppoll", "epoll_create1",
+        "epoll_ctl", "epoll_wait", "socket", "connect", "bind", "listen", "accept", "accept4",
+        "getsockname", "getpeername", "sendto", "recvfrom", "sendmsg", "recvmsg", "shutdown",
+        "setsockopt", "getsockopt", "clone", "clone3", "execve", "exit", "exit_group", "wait4",
+        "futex", "set_robust_list", "prctl", "arch_prctl", "clock_gettime", "nanosleep", "getrandom",
+        "getpid", "gettid", "uname", "readlink", "readlinkat", "getcwd", "dup", "dup2", "dup3"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}

--- a/docs/security/deployment-guide.md
+++ b/docs/security/deployment-guide.md
@@ -96,3 +96,31 @@ Environment=OPENCASTOR_ATTESTATION_PATH=/run/opencastor/attestation.json
 ```
 
 This profile is intentionally lightweight and achievable on constrained SBC deployments.
+
+## 6) Mandatory access control + seccomp profiles
+
+OpenCastor ships deployable Linux MAC/seccomp artifacts under `deploy/security/`:
+
+- `deploy/security/apparmor/opencastor-gateway` — gateway profile with constrained file paths, device nodes, and exec transitions.
+- `deploy/security/apparmor/opencastor-driver` — stricter driver-worker profile with no network access.
+- `deploy/security/seccomp/gateway-seccomp.json` — gateway syscall allow-list.
+- `deploy/security/seccomp/driver-strict-seccomp.json` — tighter driver syscall allow-list.
+
+Install and load profiles:
+
+```bash
+bash deploy/security/install_profiles.sh
+```
+
+When `castor daemon enable` is used with hardened profile (default), generated units now include:
+
+- `AppArmorProfile=opencastor-gateway` (or `opencastor-driver` for worker units)
+- `SystemCallFilter=...` seccomp hardening rules
+
+To verify runtime posture:
+
+```bash
+castor doctor
+```
+
+The doctor report includes a `MAC/seccomp` line that confirms profile installation plus active AppArmor + seccomp mode for the running daemon.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -321,6 +321,12 @@ if ! ls *.rcan.yaml &>/dev/null; then
   info "Edit robot.rcan.yaml to customize, or run 'castor wizard' to generate a new one."
 fi
 
+# Install MAC/seccomp deployment artifacts on Linux hosts
+if [ "$OS" = "linux" ] && [ "$DRY_RUN" = false ] && [ -x "deploy/security/install_profiles.sh" ]; then
+  info "Installing MAC/seccomp security profiles..."
+  run bash deploy/security/install_profiles.sh || warn "Security profile installation failed; run deploy/security/install_profiles.sh manually"
+fi
+
 # ── PATH setup — add venv/bin to shell profile ────────
 CASTOR_PATH_LINE="export PATH=\"$INSTALL_DIR/venv/bin:\$PATH\" # opencastor"
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -13,6 +13,7 @@ from castor.daemon import (
     daemon_status,
     generate_service_file,
     generate_driver_worker_units,
+    daemon_security_status,
 )
 
 
@@ -77,6 +78,8 @@ class TestGenerateServiceFile:
         assert "NoNewPrivileges=true" in content
         assert "ProtectSystem=strict" in content
         assert "DevicePolicy=closed" in content
+        assert "AppArmorProfile=opencastor-gateway" in content
+        assert "SystemCallFilter=" in content
 
     def test_permissive_profile_from_config(self, tmp_path):
         config_path = tmp_path / "robot.rcan.yaml"
@@ -86,6 +89,7 @@ class TestGenerateServiceFile:
 
         assert "NoNewPrivileges=true" not in content
         assert "DevicePolicy=closed" not in content
+        assert "AppArmorProfile=opencastor-gateway" not in content
 
 
 class TestDaemonStatus:
@@ -163,3 +167,21 @@ def test_generate_driver_worker_units(tmp_path):
     scan = units["castor-driver@scan.service"]
     assert "DeviceAllow=/dev/ttyUSB2 rw" in scan
     assert "PrivateNetwork=true" in scan
+
+
+class TestDaemonSecurityStatus:
+    def test_reports_unit_configuration_without_pid(self, tmp_path):
+        service_file = tmp_path / "castor-gateway.service"
+        service_file.write_text("AppArmorProfile=opencastor-gateway\nSystemCallFilter=@system-service\n", encoding="utf-8")
+
+        with (
+            patch("castor.daemon.SECURITY_INSTALL_PATH", tmp_path),
+            patch("castor.daemon.SERVICE_PATH", service_file),
+            patch("castor.daemon.daemon_status", return_value={"pid": None}),
+        ):
+            status = daemon_security_status()
+
+        assert status["profiles_installed"] is True
+        assert status["enabled_in_unit"] is True
+        assert status["seccomp_mode"] is None
+        assert status["apparmor_profile"] is None

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -7,6 +7,7 @@ from castor.doctor import (
     check_camera,
     check_env_file,
     check_hardware_sdks,
+    check_mac_seccomp,
     check_provider_keys,
     check_python_version,
     check_rcan_config,
@@ -122,6 +123,27 @@ class TestCheckHardwareSDKs:
             assert isinstance(ok, bool)
             assert isinstance(name, str)
             assert isinstance(detail, str)
+
+
+class TestCheckMacSeccomp:
+    @patch("castor.daemon.daemon_security_status")
+    def test_active(self, mock_status):
+        mock_status.return_value = {
+            "profiles_installed": True,
+            "enabled_in_unit": True,
+            "apparmor_profile": "opencastor-gateway (enforce)",
+            "seccomp_mode": "2",
+        }
+        ok, name, detail = check_mac_seccomp()
+        assert ok is True
+        assert name == "MAC/seccomp"
+
+    @patch("castor.daemon.daemon_security_status")
+    def test_missing_profiles(self, mock_status):
+        mock_status.return_value = {"profiles_installed": False}
+        ok, _, detail = check_mac_seccomp()
+        assert ok is False
+        assert "profiles not installed" in detail
 
 
 # =====================================================================


### PR DESCRIPTION
### Motivation

- Provide deployable Linux MAC and seccomp artifacts so gateway and drivers can be confined on target hosts. 
- Ensure installer and daemon setup activate those protections and make their runtime state discoverable by the CLI for easier validation and debugging.

### Description

- Add deployable artifacts under `deploy/security/`: AppArmor profiles (`apparmor/opencastor-gateway`, `apparmor/opencastor-driver`), seccomp JSON rules (`seccomp/gateway-seccomp.json`, `seccomp/driver-strict-seccomp.json`), an installer script (`install_profiles.sh`), and a README. 
- Enhance `generate_service_file()` and `generate_driver_worker_units()` in `castor/daemon.py` to include `AppArmorProfile=` and `SystemCallFilter=` directives when the hardened profile is used. 
- Integrate profile activation by calling a new `_install_security_profiles()` helper from `enable_daemon()` and by invoking the installer from `scripts/install.sh` on Linux installs. 
- Add runtime diagnostics: `daemon_security_status()` in `castor/daemon.py` inspects unit configuration and `/proc` to report AppArmor and seccomp state, and `check_mac_seccomp()` in `castor/doctor.py` adds a `MAC/seccomp` check to the `castor doctor` report. 
- Update documentation in `docs/security/deployment-guide.md` to describe the artifacts and validation steps. 
- Add unit tests covering service file hardening additions and the new MAC/seccomp diagnostic behavior in `tests/test_daemon.py` and `tests/test_doctor.py`.

### Testing

- Ran `pytest -q tests/test_daemon.py tests/test_doctor.py` which initially failed in a vanilla invocation due to import path resolution (ModuleNotFoundError). 
- Ran `PYTHONPATH=. pytest -q tests/test_daemon.py tests/test_doctor.py` which succeeded with `36 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0e3cab60832cb29287aaff5fcd33)