### PR TITLE
fix: VLA PaddingStrategy ImportError

### DIFF
--- a/castor/providers/vla_provider.py
+++ b/castor/providers/vla_provider.py
@@ -40,7 +40,30 @@ _ARM_JOINT_KEYS = ["grip_x", "grip_y", "grip_z", "wrist", "gripper"]
 _VLA_DEVICE = os.getenv("VLA_DEVICE", "cpu")
 _UNNORM_KEY = os.getenv("VLA_UNNORM_KEY", "bridge_orig")
 
+
+def _patch_transformers_imports() -> None:
+    """Back-fill symbols that openvla's processing_prismatic.py imports from
+    ``transformers.tokenization_utils``.
+
+    In transformers >= 4.38 (and especially 5.x dev), ``PaddingStrategy``,
+    ``PreTokenizedInput``, ``TextInput``, and ``TruncationStrategy`` were
+    relocated to ``transformers.tokenization_utils_base``.  The openvla
+    remote-code module still uses the old import path, so we patch the module
+    object in-place before AutoProcessor loads the remote code.
+    """
+    try:
+        import transformers.tokenization_utils as _tu
+        import transformers.tokenization_utils_base as _tub
+
+        for _name in ("PaddingStrategy", "PreTokenizedInput", "TextInput", "TruncationStrategy"):
+            if not hasattr(_tu, _name) and hasattr(_tub, _name):
+                setattr(_tu, _name, getattr(_tub, _name))
+    except Exception as exc:  # pragma: no cover
+        logger.debug("_patch_transformers_imports skipped: %s", exc)
+
+
 try:
+    _patch_transformers_imports()
     from PIL import Image as _PILImage
     from transformers import AutoModelForVision2Seq, AutoProcessor
 

--- a/tests/test_vla_provider.py
+++ b/tests/test_vla_provider.py
@@ -217,3 +217,91 @@ def test_get_provider_returns_vla_provider():
 
     p = get_provider({"provider": "vla", "model": "openvla/openvla-7b"})
     assert isinstance(p, vmod.VLAProvider)
+
+
+# ---------------------------------------------------------------------------
+# Regression: PaddingStrategy ImportError (#793)
+# ---------------------------------------------------------------------------
+
+
+def test_patch_transformers_imports_no_error():
+    """_patch_transformers_imports() must not raise regardless of transformers version."""
+    sys.modules.pop("castor.providers.vla_provider", None)
+    import castor.providers.vla_provider as vmod  # noqa: PLC0415
+
+    # Calling the patch function again should be idempotent and never raise.
+    vmod._patch_transformers_imports()
+
+
+def test_patch_transformers_imports_exposes_padding_strategy():
+    """After _patch_transformers_imports(), PaddingStrategy must be accessible
+    on transformers.tokenization_utils (the path openvla remote code uses)."""
+    sys.modules.pop("castor.providers.vla_provider", None)
+    import castor.providers.vla_provider as vmod  # noqa: PLC0415
+
+    vmod._patch_transformers_imports()
+
+    import transformers.tokenization_utils as tu  # noqa: PLC0415
+
+    assert hasattr(tu, "PaddingStrategy"), (
+        "PaddingStrategy missing from transformers.tokenization_utils after patch — "
+        "openvla's processing_prismatic.py will fail to import"
+    )
+
+
+def test_patch_transformers_imports_exposes_all_relocated_symbols():
+    """All four symbols relocated in transformers 5.x must be present after patching."""
+    sys.modules.pop("castor.providers.vla_provider", None)
+    import castor.providers.vla_provider as vmod  # noqa: PLC0415
+
+    vmod._patch_transformers_imports()
+
+    import transformers.tokenization_utils as tu  # noqa: PLC0415
+
+    for name in ("PaddingStrategy", "PreTokenizedInput", "TextInput", "TruncationStrategy"):
+        assert hasattr(tu, name), f"{name} missing from transformers.tokenization_utils after patch"
+
+
+def test_patch_survives_missing_transformers(monkeypatch):
+    """_patch_transformers_imports() must not raise even if transformers is absent."""
+    import builtins  # noqa: PLC0415
+
+    real_import = builtins.__import__
+
+    def _mock_import(name, *args, **kwargs):
+        if name.startswith("transformers"):
+            raise ImportError(f"mocked absence of {name}")
+        return real_import(name, *args, **kwargs)
+
+    sys.modules.pop("castor.providers.vla_provider", None)
+    import castor.providers.vla_provider as vmod  # noqa: PLC0415
+
+    monkeypatch.setattr(builtins, "__import__", _mock_import)
+    # Must not raise
+    vmod._patch_transformers_imports()
+
+
+def test_vla_provider_imports_without_import_error():
+    """Importing VLAProvider must never raise ImportError (issue #793 regression)."""
+    sys.modules.pop("castor.providers.vla_provider", None)
+    try:
+        from castor.providers.vla_provider import VLAProvider  # noqa: F401, PLC0415
+    except ImportError as exc:
+        pytest.fail(f"VLAProvider import raised ImportError: {exc}")
+
+
+def test_mock_mode_works_without_openvla():
+    """VLAProvider must operate in mock mode when openvla weights are unavailable.
+
+    The confidence from mock mode (0.55) is intentionally below the 0.60 gate
+    so planning brain escalation fires correctly.
+    """
+    sys.modules.pop("castor.providers.vla_provider", None)
+    import castor.providers.vla_provider as vmod  # noqa: PLC0415
+
+    vmod.HAS_TRANSFORMERS = False
+    p = vmod.VLAProvider({"provider": "vla", "model": "openvla/openvla-7b"})
+    assert p._mode == "mock"
+    thought = p.think(b"", "move forward")
+    assert thought.action["confidence"] == pytest.approx(0.55)
+    assert thought.action["brain"] == "vla_mock"


### PR DESCRIPTION
## Summary

Closes #793

### Root Cause

`transformers 5.0.0.dev0` relocated four tokenizer symbols out of `transformers.tokenization_utils` into `transformers.tokenization_utils_base`:

- `PaddingStrategy`
- `PreTokenizedInput`
- `TextInput`
- `TruncationStrategy`

openvla's `processing_prismatic.py` (loaded via `trust_remote_code=True`) still imports from the old path, triggering an `ImportError` that silently drops `VLAProvider` into mock mode (confidence 0.55, below the 0.60 dual-brain gate).

### Fix

Added `_patch_transformers_imports()` to `castor/providers/vla_provider.py`, called at module load time before `AutoProcessor`/`AutoModelForVision2Seq` are imported. The function patches `transformers.tokenization_utils` in-place so all four symbols are always present, regardless of transformers version. The patch is:

- **idempotent** — safe to call multiple times
- **silent** — logs `DEBUG` and swallows exceptions if transformers is absent
- **version-agnostic** — only adds symbols that are missing; does not overwrite existing ones

### Tests

6 new regression tests in `tests/test_vla_provider.py`:

1. `test_patch_transformers_imports_no_error` — function never raises
2. `test_patch_transformers_imports_exposes_padding_strategy` — PaddingStrategy available after patch
3. `test_patch_transformers_imports_exposes_all_relocated_symbols` — all 4 symbols present
4. `test_patch_survives_missing_transformers` — safe when transformers not installed
5. `test_vla_provider_imports_without_import_error` — module-level import succeeds
6. `test_mock_mode_works_without_openvla` — mock confidence still 0.55 (escalation gate intact)

All 24 tests pass (`python3 -m pytest tests/test_vla_provider.py -q --timeout=20`).