### PR TITLE
feat: typed PermissionMode per-tool + named profiles $deep/$quick (#815 #818)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ alex.rcan.yaml
 9.rcan.yaml
 .worktrees/
 config/swarm.yaml
+.worktrees/


### PR DESCRIPTION
Adds `castor/tools/permissions.py` — `PermissionMode` enum (READ_ONLY→SAFETY_OVERRIDE), `TOOL_PERMISSIONS` table, `check_permission()` wired into `api.py` dispatch. Adds `castor/tools/profiles.py` — `ExecutionProfile` dataclass, `PROFILES` with `deep`/`quick`, `parse_profile_prefix()` for `$deep`/`$quick` message routing. 11 tests. Closes #815 #818.