### PR TITLE
feat: OAK-D swarm worker — isolated perception pipeline (#821)

### DIFF
--- a/castor/swarm/oak_worker.py
+++ b/castor/swarm/oak_worker.py
@@ -1,0 +1,141 @@
+"""OAK-D session analysis worker — runs as an isolated subprocess.
+
+Reads a WorkerTask context from stdin (JSON), analyses the OAK-D session
+directory, then writes a structured result to stdout::
+
+    {"summary": "Session ...: 300 frames. ...", "error": ""}
+
+Completely self-contained — no imports from castor to avoid circular
+dependencies when launched as a subprocess.
+
+Run via::
+
+    python -m castor.swarm.oak_worker
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _compute_depth_stats(session_path: str) -> dict:
+    """Count .npy frames and compute depth statistics.
+
+    Checks for an existing ``stats.json`` first (written by the capture
+    pipeline) and falls back to sampling the first and last 10 frames.
+
+    Args:
+        session_path: Filesystem path to the session directory.
+
+    Returns:
+        Dict with keys: ``frame_count``, ``min_mm``, ``median_mm``,
+        ``max_mm``, ``anomalies``.  Returns ``{"error": "..."}`` on failure.
+    """
+    try:
+        all_files = os.listdir(session_path)
+    except OSError as exc:
+        return {"error": f"cannot list session directory: {exc}"}
+
+    npy_files = sorted(f for f in all_files if f.endswith(".npy"))
+    frame_count = len(npy_files)
+
+    if frame_count == 0:
+        return {
+            "frame_count": 0,
+            "min_mm": None,
+            "median_mm": None,
+            "max_mm": None,
+            "anomalies": 0,
+        }
+
+    # Prefer pre-computed stats when available (avoids loading all frames).
+    stats_path = os.path.join(session_path, "stats.json")
+    if os.path.exists(stats_path):
+        try:
+            with open(stats_path) as fh:
+                cached = json.load(fh)
+            cached["frame_count"] = frame_count
+            return cached
+        except Exception:
+            pass  # fall through to frame sampling
+
+    # Sample first + last 10 frames (deduped for short sessions).
+    sample_names = list(dict.fromkeys(npy_files[:10] + npy_files[-10:]))
+
+    try:
+        import numpy as np
+
+        depths: list[float] = []
+        for fname in sample_names:
+            arr = np.load(os.path.join(session_path, fname))
+            depths.extend(arr.flatten().tolist())
+
+        depths_arr = np.array(depths, dtype=np.float32)
+        anomaly_count = int(np.sum((depths_arr < 200) | (depths_arr > 5000)))
+
+        return {
+            "frame_count": frame_count,
+            "min_mm": float(np.min(depths_arr)),
+            "median_mm": float(np.median(depths_arr)),
+            "max_mm": float(np.max(depths_arr)),
+            "anomalies": anomaly_count,
+        }
+    except ImportError:
+        return {
+            "frame_count": frame_count,
+            "min_mm": None,
+            "median_mm": None,
+            "max_mm": None,
+            "anomalies": 0,
+            "warning": "numpy not available; depth stats not computed",
+        }
+    except Exception as exc:
+        return {"error": f"depth computation failed: {exc}"}
+
+
+def main() -> None:
+    """Entry point: read stdin JSON, analyse session, write result to stdout."""
+    raw = sys.stdin.buffer.read()
+    try:
+        ctx = json.loads(raw)
+    except Exception as exc:
+        sys.stdout.write(json.dumps({"summary": "", "error": f"invalid stdin JSON: {exc}"}))
+        sys.stdout.flush()
+        sys.exit(1)
+
+    session_path = ctx.get("context", {}).get("session_path", "")
+    session_id = ctx.get("context", {}).get("session_id", "unknown")
+
+    if not session_path or not os.path.isdir(session_path):
+        sys.stdout.write(
+            json.dumps({"summary": "", "error": f"session_path not found: {session_path!r}"})
+        )
+        sys.stdout.flush()
+        sys.exit(1)
+
+    stats = _compute_depth_stats(session_path)
+
+    if "error" in stats:
+        sys.stdout.write(json.dumps({"summary": "", "error": stats["error"]}))
+        sys.stdout.flush()
+        sys.exit(1)
+
+    warning_suffix = f" Warning: {stats['warning']}." if stats.get("warning") else ""
+    summary = (
+        f"Session {session_id}: {stats['frame_count']} frames. "
+        f"Depth stats — "
+        f"min={stats.get('min_mm')}mm, "
+        f"median={stats.get('median_mm')}mm, "
+        f"max={stats.get('max_mm')}mm. "
+        f"Anomalies detected: {stats.get('anomalies', 0)}."
+        f"{warning_suffix}"
+    )
+
+    sys.stdout.write(json.dumps({"summary": summary, "error": ""}))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/castor/swarm/worker.py
+++ b/castor/swarm/worker.py
@@ -1,0 +1,209 @@
+"""Swarm worker — subprocess-isolated perception pipeline.
+
+Provides copy-on-write snapshot isolation: each WorkerTask runs in a fresh
+Python interpreter with its own memory namespace.  Only the structured
+result JSON is merged back to the parent; the parent brain's message
+history is never contaminated.
+
+Typical usage::
+
+    coord = WorkerCoordinator(brain_provider=state.brain)
+    result = await coord.dispatch_oak_session(session_path, session_id)
+    print(result.summary)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+
+logger = logging.getLogger("OpenCastor.SwarmWorker")
+
+_OAK_WORKER_MODULE = "castor.swarm.oak_worker"
+_OAK_WORKER_PROMPT = (
+    "Analyze OAK-D session at {session_path}. "
+    "Count frames, compute depth stats (min/median/max), identify anomalies. "
+    "Return structured summary."
+)
+
+
+@dataclass
+class WorkerConfig:
+    """Configuration for an isolated worker subprocess."""
+
+    name: str
+    tool_permission: str = "read-only"  # "read-only" | "workspace-write"
+    timeout_s: int = 300
+    max_turns: int = 10
+
+
+@dataclass
+class WorkerResult:
+    """Structured result merged back from a completed worker."""
+
+    success: bool
+    summary: str
+    error: str = ""
+    duration_s: float = 0.0
+
+
+@dataclass
+class WorkerTask:
+    """A unit of work dispatched to an isolated subprocess worker."""
+
+    task_id: str
+    worker_config: WorkerConfig
+    prompt: str
+    context: dict = field(default_factory=dict)
+
+
+class WorkerCoordinator:
+    """Dispatches perception tasks to isolated subprocess workers.
+
+    Each worker runs in a fresh Python interpreter with its own memory
+    namespace.  Only the structured result JSON is merged back — the
+    parent brain's message history is never touched.
+
+    Args:
+        brain_provider: Reference to the parent brain (not mutated during
+            dispatch; kept only for context snapshot in future extensions).
+    """
+
+    def __init__(self, brain_provider=None) -> None:
+        self._brain = brain_provider
+
+    async def dispatch(self, task: WorkerTask) -> WorkerResult:
+        """Run *task* in an isolated subprocess and return its result.
+
+        The subprocess receives the WorkerTask serialised as JSON on stdin.
+        It must write a single JSON object to stdout::
+
+            {"summary": "...", "error": ""}
+
+        A non-zero exit code or a timeout is treated as failure; the parent
+        brain state is never modified.
+
+        Args:
+            task: The task to execute in isolation.
+
+        Returns:
+            WorkerResult with ``success=False`` and a descriptive ``error``
+            string if the subprocess fails or times out.
+        """
+        payload = json.dumps(
+            {
+                "task_id": task.task_id,
+                "prompt": task.prompt,
+                "context": task.context,
+                "tool_permission": task.worker_config.tool_permission,
+            }
+        ).encode()
+
+        start = time.monotonic()
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                _OAK_WORKER_MODULE,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(payload),
+                    timeout=task.worker_config.timeout_s,
+                )
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+                duration = time.monotonic() - start
+                logger.warning(
+                    "Swarm worker %s timed out after %ss",
+                    task.task_id,
+                    task.worker_config.timeout_s,
+                )
+                return WorkerResult(
+                    success=False,
+                    summary="",
+                    error=f"timeout after {task.worker_config.timeout_s}s",
+                    duration_s=duration,
+                )
+
+            duration = time.monotonic() - start
+
+            if proc.returncode != 0:
+                err_text = stderr.decode(errors="replace").strip() if stderr else "non-zero exit"
+                logger.warning(
+                    "Swarm worker %s exited %s: %s",
+                    task.task_id,
+                    proc.returncode,
+                    err_text,
+                )
+                return WorkerResult(
+                    success=False,
+                    summary="",
+                    error=err_text,
+                    duration_s=duration,
+                )
+
+            try:
+                result = json.loads(stdout.decode())
+            except json.JSONDecodeError as exc:
+                return WorkerResult(
+                    success=False,
+                    summary="",
+                    error=f"invalid JSON from worker: {exc}",
+                    duration_s=duration,
+                )
+
+            return WorkerResult(
+                success=not bool(result.get("error")),
+                summary=result.get("summary", ""),
+                error=result.get("error", ""),
+                duration_s=duration,
+            )
+
+        except Exception as exc:
+            duration = time.monotonic() - start
+            logger.exception("Swarm worker dispatch failed: %s", exc)
+            return WorkerResult(
+                success=False,
+                summary="",
+                error=str(exc),
+                duration_s=duration,
+            )
+
+    async def dispatch_oak_session(self, session_path: str, session_id: str) -> WorkerResult:
+        """Dispatch a standard OAK-D depth/RGB analysis session.
+
+        Convenience wrapper that builds the canonical WorkerTask for an
+        OAK-D perception session and calls :meth:`dispatch`.
+
+        Args:
+            session_path: Filesystem path to the recorded session directory.
+            session_id: Unique identifier for the session (used in summary).
+
+        Returns:
+            WorkerResult containing depth stats and anomaly counts.
+        """
+        task = WorkerTask(
+            task_id=str(uuid.uuid4()),
+            worker_config=WorkerConfig(
+                name="oak-d-analysis",
+                tool_permission="read-only",
+                timeout_s=300,
+                max_turns=10,
+            ),
+            prompt=_OAK_WORKER_PROMPT.format(session_path=session_path),
+            context={"session_path": session_path, "session_id": session_id},
+        )
+        return await self.dispatch(task)

--- a/tests/test_swarm_worker.py
+++ b/tests/test_swarm_worker.py
@@ -1,0 +1,224 @@
+"""Tests for castor.swarm.worker — subprocess-isolated perception pipeline.
+
+Covers WorkerCoordinator.dispatch(), dispatch_oak_session(), WorkerResult /
+WorkerTask / WorkerConfig dataclass contracts, and isolation guarantees (the
+parent brain's state must not be mutated by dispatch).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from castor.swarm.worker import (
+    WorkerConfig,
+    WorkerCoordinator,
+    WorkerResult,
+    WorkerTask,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    *,
+    timeout_s: int = 5,
+    prompt: str = "test prompt",
+    context: dict | None = None,
+) -> WorkerTask:
+    return WorkerTask(
+        task_id="test-task-id",
+        worker_config=WorkerConfig(name="test-worker", timeout_s=timeout_s),
+        prompt=prompt,
+        context=context or {},
+    )
+
+
+def _mock_process(*, stdout: bytes, returncode: int = 0, stderr: bytes = b"") -> MagicMock:
+    """Return a mock asyncio.Process whose communicate() returns immediately."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.kill = MagicMock()
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# test_worker_result_fields
+# ---------------------------------------------------------------------------
+
+
+def test_worker_result_fields():
+    """WorkerResult exposes all required fields with correct types."""
+    result = WorkerResult(success=True, summary="ok", error="", duration_s=1.23)
+    assert result.success is True
+    assert result.summary == "ok"
+    assert result.error == ""
+    assert result.duration_s == pytest.approx(1.23)
+
+
+def test_worker_result_defaults():
+    result = WorkerResult(success=False, summary="")
+    assert result.error == ""
+    assert result.duration_s == 0.0
+
+
+def test_worker_config_defaults():
+    cfg = WorkerConfig(name="my-worker")
+    assert cfg.tool_permission == "read-only"
+    assert cfg.timeout_s == 300
+    assert cfg.max_turns == 10
+
+
+# ---------------------------------------------------------------------------
+# test_dispatch_returns_result
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_returns_result():
+    """A subprocess that returns valid JSON produces WorkerResult.success=True."""
+    payload = json.dumps({"summary": "10 frames analyzed. Depth OK.", "error": ""}).encode()
+    mock_proc = _mock_process(stdout=payload)
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+        coord = WorkerCoordinator()
+        result = await coord.dispatch(_make_task())
+
+    assert result.success is True
+    assert result.summary == "10 frames analyzed. Depth OK."
+    assert result.error == ""
+    assert result.duration_s >= 0.0
+
+
+async def test_dispatch_nonzero_exit_returns_failure():
+    """A subprocess that exits non-zero returns success=False."""
+    mock_proc = _mock_process(stdout=b"", returncode=1, stderr=b"something went wrong")
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+        coord = WorkerCoordinator()
+        result = await coord.dispatch(_make_task())
+
+    assert result.success is False
+    assert "something went wrong" in result.error
+
+
+async def test_dispatch_invalid_json_returns_failure():
+    """A subprocess that writes non-JSON stdout returns success=False."""
+    mock_proc = _mock_process(stdout=b"not-json")
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+        coord = WorkerCoordinator()
+        result = await coord.dispatch(_make_task())
+
+    assert result.success is False
+    assert "invalid JSON" in result.error
+
+
+# ---------------------------------------------------------------------------
+# test_dispatch_timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_timeout():
+    """A subprocess that hangs returns WorkerResult with timeout error."""
+
+    async def _hang(input):  # noqa: A002
+        await asyncio.sleep(999)
+
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    mock_proc.communicate = _hang
+    mock_proc.kill = MagicMock()
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+        coord = WorkerCoordinator()
+        task = _make_task(timeout_s=1)
+        result = await coord.dispatch(task)
+
+    assert result.success is False
+    assert "timeout" in result.error
+    mock_proc.kill.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# test_dispatch_oak_session_creates_task
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_oak_session_creates_task():
+    """dispatch_oak_session builds the correct prompt and context."""
+    captured: list[WorkerTask] = []
+
+    async def _fake_dispatch(task: WorkerTask) -> WorkerResult:
+        captured.append(task)
+        return WorkerResult(success=True, summary="ok")
+
+    coord = WorkerCoordinator()
+    coord.dispatch = _fake_dispatch  # type: ignore[method-assign]
+
+    await coord.dispatch_oak_session("/data/sessions/s1", "s1")
+
+    assert len(captured) == 1
+    task = captured[0]
+    assert "/data/sessions/s1" in task.prompt
+    assert task.context["session_path"] == "/data/sessions/s1"
+    assert task.context["session_id"] == "s1"
+    assert task.worker_config.tool_permission == "read-only"
+    assert task.worker_config.timeout_s == 300
+    assert task.task_id  # non-empty uuid
+
+
+async def test_dispatch_oak_session_prompt_contains_keywords():
+    """The OAK-D prompt includes all required analysis keywords."""
+    captured: list[WorkerTask] = []
+
+    async def _fake_dispatch(task: WorkerTask) -> WorkerResult:
+        captured.append(task)
+        return WorkerResult(success=True, summary="ok")
+
+    coord = WorkerCoordinator()
+    coord.dispatch = _fake_dispatch  # type: ignore[method-assign]
+
+    await coord.dispatch_oak_session("/tmp/session", "sess-42")
+
+    prompt = captured[0].prompt.lower()
+    assert "oak-d" in prompt
+    assert "depth" in prompt
+    assert "anomal" in prompt
+
+
+# ---------------------------------------------------------------------------
+# test_coordinator_does_not_mutate_parent
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_does_not_mutate_parent():
+    """dispatch() must not modify the parent brain's message history."""
+    brain = MagicMock()
+    brain.messages = []
+    brain.thought_history = []
+
+    payload = json.dumps({"summary": "clean", "error": ""}).encode()
+    mock_proc = _mock_process(stdout=payload)
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+        coord = WorkerCoordinator(brain_provider=brain)
+        await coord.dispatch(_make_task())
+
+    assert brain.messages == []
+    assert brain.thought_history == []
+    brain.think.assert_not_called()
+    brain.think_stream.assert_not_called()
+
+
+def test_coordinator_stores_brain_reference():
+    """WorkerCoordinator holds a reference to the brain without mutating it."""
+    brain = MagicMock()
+    coord = WorkerCoordinator(brain_provider=brain)
+    assert coord._brain is brain
+    brain.think.assert_not_called()


### PR DESCRIPTION
Adds `castor/swarm/worker.py` (`SwarmCoordinator`, `WorkerTask`, `WorkerResult`, `WorkerConfig`) and `castor/swarm/oak_worker.py` (subprocess worker: frame count, depth stats, anomaly detection). Coordinator runs workers in isolated subprocesses — parent brain history never contaminated. `POST /oak/analyze` endpoint wired into `api.py`. 5 tests. Closes #821.