### PR TITLE
feat: autoDream auto-files GitHub issues on detected problems

### DIFF
--- a/castor/brain/__init__.py
+++ b/castor/brain/__init__.py
@@ -1,3 +1,4 @@
+from castor.brain.autodream_issues import IssueTemplate, build_issue_template, file_github_issue
 from castor.brain.compaction import (
     CompactionStrategy,
     build_continuation_message,
@@ -8,8 +9,11 @@ from castor.brain.compaction import (
 
 __all__ = [
     "CompactionStrategy",
+    "IssueTemplate",
     "build_continuation_message",
+    "build_issue_template",
     "compact_session",
     "estimate_tokens",
+    "file_github_issue",
     "should_compact",
 ]

--- a/castor/brain/autodream_issues.py
+++ b/castor/brain/autodream_issues.py
@@ -1,0 +1,108 @@
+"""autoDream issue filer — auto-files GitHub issues for detected problems.
+
+Called by autodream_runner when DreamResult.issues_detected is non-empty.
+Uses the `gh` CLI so no token management is needed in Python.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+
+logger = logging.getLogger("OpenCastor.AutoDreamIssues")
+
+
+@dataclass
+class IssueTemplate:
+    """Structured GitHub issue ready to file."""
+
+    title: str
+    body: str
+    labels: list[str] = field(default_factory=lambda: ["autodream", "needs-triage"])
+
+
+def build_issue_template(issue_text: str, robot_rrn: str, date: str) -> IssueTemplate:
+    """Build an IssueTemplate from a plain-English issue description.
+
+    Args:
+        issue_text: Raw description from the LLM (one issue per string).
+        robot_rrn:  RRN of the robot that generated the issue.
+        date:       ISO date string (YYYY-MM-DD) for the dream run.
+
+    Returns:
+        IssueTemplate with title truncated to 80 chars, a structured body,
+        and labels ``["autodream", "needs-triage"]``.
+    """
+    # Title: first sentence if available, else raw text — truncated to 80 chars.
+    first_sentence = issue_text.split(".")[0].strip()
+    raw_title = first_sentence if first_sentence else issue_text
+    title = raw_title[:80]
+
+    body = (
+        f"**Auto-detected by autoDream on {date}**\n\n"
+        f"Robot: {robot_rrn}\n\n"
+        f"{issue_text}\n\n"
+        "---\n"
+        "*Filed automatically by castor/brain/autodream_runner.py*"
+    )
+
+    return IssueTemplate(title=title, body=body)
+
+
+def file_github_issue(
+    template: IssueTemplate,
+    repo: str,
+    dry_run: bool = False,
+) -> str | None:
+    """File a GitHub issue via the ``gh`` CLI.
+
+    Args:
+        template: Populated IssueTemplate to file.
+        repo:     GitHub repo slug, e.g. ``"craigm26/OpenCastor"``.
+        dry_run:  If True, log intent but do not execute the CLI command.
+
+    Returns:
+        The issue URL string on success, or ``None`` on failure / dry-run.
+        Never raises.
+    """
+    if dry_run:
+        logger.info("autoDream [dry-run] would file issue: %r on %s", template.title, repo)
+        return None
+
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        template.title,
+        "--body",
+        template.body,
+        "--label",
+        "autodream",
+        "--label",
+        "needs-triage",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            url = result.stdout.strip()
+            logger.info("autoDream filed issue: %s", url)
+            return url
+        logger.warning(
+            "autoDream: gh issue create failed (rc=%d): %s",
+            result.returncode,
+            result.stderr.strip(),
+        )
+    except Exception as exc:
+        logger.warning("autoDream: could not file GitHub issue: %s", exc)
+
+    return None

--- a/castor/brain/autodream_runner.py
+++ b/castor/brain/autodream_runner.py
@@ -21,11 +21,18 @@ from datetime import datetime
 from pathlib import Path
 
 from castor.brain.autodream import AutoDreamBrain, DreamResult, DreamSession
+from castor.brain.autodream_issues import build_issue_template, file_github_issue
 
 logger = logging.getLogger("OpenCastor.AutoDreamRunner")
 
 # Cheap, fast model for nightly runs — overridable via env.
 DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+# Set CASTOR_AUTODREAM_DRY_RUN=1 to skip actual gh issue creation.
+DRY_RUN = os.getenv("CASTOR_AUTODREAM_DRY_RUN", "0") != "0"
+
+# GitHub repo to file issues against — overridable via env.
+DEFAULT_GITHUB_REPO = "craigm26/OpenCastor"
 
 OPENCASTOR_DIR = Path.home() / ".opencastor"
 MEMORY_FILE = OPENCASTOR_DIR / "robot-memory.md"
@@ -100,13 +107,18 @@ def _atomic_write(path: Path, content: str) -> None:
         raise
 
 
-def _append_dream_log(date_str: str, result: DreamResult) -> None:
+def _append_dream_log(
+    date_str: str,
+    result: DreamResult,
+    issue_urls: list[str] | None = None,
+) -> None:
     """Append a structured entry to dream-log.jsonl."""
     entry = {
         "date": date_str,
         "learnings": result.learnings,
         "issues": result.issues_detected,
         "summary": result.summary,
+        "issue_urls": issue_urls or [],
     }
     try:
         OPENCASTOR_DIR.mkdir(parents=True, exist_ok=True)
@@ -171,10 +183,22 @@ def main() -> None:
         print(f"autoDream: failed to write robot-memory.md: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    # 6. Append to dream log
-    _append_dream_log(today, result)
+    # 6. File GitHub issues for detected problems
+    issue_urls: list[str] = []
+    if result.issues_detected:
+        repo = os.getenv("CASTOR_GITHUB_REPO", DEFAULT_GITHUB_REPO)
+        rrn = os.getenv("CASTOR_RRN", "unknown")
+        for issue_text in result.issues_detected:
+            template = build_issue_template(issue_text, rrn, today)
+            url = file_github_issue(template, repo, dry_run=DRY_RUN)
+            if url:
+                issue_urls.append(url)
+        logger.info("autoDream filed %d issue(s)", len(issue_urls))
 
-    # 7. Print summary to stdout (captured by autodream.sh)
+    # 7. Append to dream log
+    _append_dream_log(today, result, issue_urls=issue_urls)
+
+    # 8. Print summary to stdout (captured by autodream.sh)
     print(result.summary or f"autoDream {today}: complete")
 
     sys.exit(0)

--- a/tests/test_autodream_issues.py
+++ b/tests/test_autodream_issues.py
@@ -1,0 +1,98 @@
+"""Tests for castor.brain.autodream_issues."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from castor.brain.autodream_issues import IssueTemplate, build_issue_template, file_github_issue
+
+
+class TestBuildIssueTemplate:
+    def test_build_issue_template_title_truncated(self):
+        long_text = "A" * 120
+        template = build_issue_template(long_text, "RRN-000000000001", "2026-04-01")
+        assert len(template.title) <= 80
+
+    def test_build_issue_template_includes_rrn(self):
+        rrn = "rrn://craigm26/robot/opencastor-rpi5-hailo/bob-001"
+        template = build_issue_template("Motor stall detected.", rrn, "2026-04-01")
+        assert rrn in template.body
+
+    def test_build_issue_template_has_autodream_label(self):
+        template = build_issue_template("Some issue text.", "RRN-000000000001", "2026-04-01")
+        assert "autodream" in template.labels
+        assert "needs-triage" in template.labels
+
+    def test_build_issue_template_title_uses_first_sentence(self):
+        text = "Motor stall detected. This happened three times. Check the wiring."
+        template = build_issue_template(text, "RRN-000000000001", "2026-04-01")
+        assert template.title == "Motor stall detected"
+
+    def test_build_issue_template_body_contains_date(self):
+        template = build_issue_template("Some issue.", "RRN-1", "2026-04-01")
+        assert "2026-04-01" in template.body
+
+    def test_build_issue_template_body_has_attribution(self):
+        template = build_issue_template("Some issue.", "RRN-1", "2026-04-01")
+        assert "autodream_runner.py" in template.body
+
+
+class TestFileGithubIssue:
+    def test_file_github_issue_dry_run_returns_none(self):
+        template = IssueTemplate(
+            title="Test issue",
+            body="Body text",
+            labels=["autodream", "needs-triage"],
+        )
+        with patch("subprocess.run") as mock_run:
+            result = file_github_issue(template, "craigm26/OpenCastor", dry_run=True)
+        assert result is None
+        mock_run.assert_not_called()
+
+    def test_file_github_issue_calls_gh_cli(self):
+        template = IssueTemplate(
+            title="Test issue",
+            body="Body text",
+            labels=["autodream", "needs-triage"],
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "https://github.com/craigm26/OpenCastor/issues/42\n"
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            url = file_github_issue(template, "craigm26/OpenCastor", dry_run=False)
+
+        assert url == "https://github.com/craigm26/OpenCastor/issues/42"
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "gh" in cmd
+        assert "issue" in cmd
+        assert "create" in cmd
+        assert "--repo" in cmd
+        assert "craigm26/OpenCastor" in cmd
+
+    def test_file_github_issue_returns_none_on_gh_failure(self):
+        template = IssueTemplate(
+            title="Test issue",
+            body="Body text",
+            labels=["autodream", "needs-triage"],
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "HTTP 422: label not found"
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = file_github_issue(template, "craigm26/OpenCastor", dry_run=False)
+
+        assert result is None
+
+    def test_file_github_issue_returns_none_on_exception(self):
+        template = IssueTemplate(
+            title="Test issue",
+            body="Body",
+            labels=["autodream"],
+        )
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh not found")):
+            result = file_github_issue(template, "craigm26/OpenCastor", dry_run=False)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Adds `castor/brain/autodream_issues.py` with `IssueTemplate`, `build_issue_template()`, and `file_github_issue()` — the new issue-filing layer
- Wires issue filing into `autodream_runner.py` after the dream log write; runs once per detected issue using the `gh` CLI
- Exports `IssueTemplate`, `build_issue_template`, `file_github_issue` from `castor/brain/__init__.py`
- 10 new tests in `tests/test_autodream_issues.py` covering title truncation, RRN inclusion, label presence, dry-run no-op, gh CLI invocation, and failure handling

## Env vars

| Var | Default | Purpose |
|-----|---------|---------|
| `CASTOR_GITHUB_REPO` | `craigm26/OpenCastor` | Repo to file issues against |
| `CASTOR_AUTODREAM_DRY_RUN` | `0` | Set to `1` to skip actual `gh` calls |
| `CASTOR_RRN` | `unknown` | Robot RRN stamped on issue body |

## Test plan

- [x] `pytest tests/test_autodream_issues.py` — 10/10 passing
- [x] `pytest tests/test_autodream.py` — 5/5 passing (no regressions)
- [x] `ruff check` — clean
- [ ] Manual: set `CASTOR_AUTODREAM_DRY_RUN=1` and verify log output only
- [ ] Manual: end-to-end with real `gh` auth on a test repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)