### PR TITLE
fix: bump Node to 20.19 in demo-pages CI (vite 8 requires ^20.19.0)

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: '20.19'  # vite 8 requires ^20.19.0 || >=22.12.0
           cache: npm
           cache-dependency-path: demo/package-lock.json
 


### PR DESCRIPTION
Vite 8.0.3 requires `engines.node: ^20.19.0 || >=22.12.0`. The CI was using `node-version: 20` which resolves to 20.x latest on the runner — currently below 20.19, causing `npm ci` to fail with an engines incompatibility error.\n\nFix: pin to `20.19` (satisfies vite 8 without jumping to Node 22).