### PR TITLE
feat: v2026.4.2.0 — structured robot memory + autoDream KAIROS v2 + castor memory CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Versions use date-based scheme: `YYYY.MM.DD.patch`.
 
 ---
 
+## [2026.4.2.0] - 2026-04-02
+
+### Added — Structured Robot Memory (KAIROS v2)
+- `castor/brain/memory_schema.py` — `MemoryEntry` + `RobotMemory` dataclasses; typed entries (`hardware_observation`, `environment_note`, `behavior_pattern`, `resolved`); confidence scoring 0.0–1.0 with 0.05/day decay; `load_memory()` / `save_memory()` (atomic); `filter_for_context()` (inject threshold 0.30); `prune_entries()` (prune threshold 0.10); `format_entries_for_context()` (🔴🟡🟢 confidence prefixes)
+- `castor memory show` CLI — display all entries with confidence bars, injection eligibility, observation counts
+- `castor memory add` CLI — manually add typed memory entries with confidence + tags
+- `castor memory prune` CLI — remove entries below threshold (with `--dry-run`)
+- `castor memory decay` CLI — apply time-based confidence decay and save
+- `castor/brain/robot_context.py` now injects structured memory at brain session start; graceful fallback to free-form text for existing files
+
+### Changed — autoDream Structured Output
+- `castor/brain/autodream.py` — `AUTODREAM_SYSTEM_PROMPT` updated to request structured `entries` JSON (type/text/confidence/tags); `DreamResult` gains `entries: list[dict]` field; `_parse_response()` supports both new structured and legacy `updated_memory` formats
+- `castor/brain/autodream_runner.py` — `_write_structured_memory()`: upserts new entries via `memory_schema`, reinforces matching existing entries (+0.1 nudge), prunes below threshold; falls back to free-form write if no structured entries returned
+- autoDream session prompt now shows existing memory in 🔴🟡🟢 context format so the LLM can reinforce or avoid duplicating observations
+
+### Fixed
+- `website/` — Astro 5→5.18.1; patches picomatch 4.0.4, h3 1.15.11, smol-toml 1.6.1 (7 Dependabot security alerts)
+
+---
+
 ## [2026.4.1.0] - 2026-04-01
 
 ### Added — Post-Quantum Cryptography

--- a/castor/brain/autodream.py
+++ b/castor/brain/autodream.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from castor.providers.base import BaseProvider
@@ -21,11 +21,22 @@ logger = logging.getLogger("OpenCastor.AutoDream")
 AUTODREAM_SYSTEM_PROMPT = (
     "You are the autoDream brain for an OpenCastor robot. Your job is to:\n"
     "1. Read recent session logs and health data\n"
-    "2. Distill new learnings (patterns, recurring errors, calibration notes)\n"
-    "3. Update the robot memory file with only what is NEW and USEFUL — prune stale entries\n"
+    "2. Distill new learnings (hardware patterns, environment notes, behavior adjustments)\n"
+    "3. Return ONLY new or updated observations — not a full memory rewrite\n"
     "4. Identify actionable issues that warrant a GitHub issue or PR\n"
-    "5. Be concise — robot-memory.md should stay under 200 lines\n"
-    "Format your response as JSON with keys: updated_memory, learnings, issues_detected, summary"
+    "5. Be concise — one observation per entry, max 500 chars each\n"
+    "\n"
+    "Format your response as JSON with keys:\n"
+    "  entries: list of {type, text, confidence, tags} where:\n"
+    "    type: 'hardware_observation' | 'environment_note' | 'behavior_pattern' | 'resolved'\n"
+    "    text: concise observation string (max 500 chars)\n"
+    "    confidence: float 0.0–1.0 (how certain you are)\n"
+    "    tags: list of string labels (optional)\n"
+    "  learnings: list of short learning strings (for the dream log)\n"
+    "  issues_detected: list of issue descriptions to file as GitHub issues\n"
+    "  summary: one-line summary of the dream session\n"
+    "\n"
+    "Return empty entries list if no new observations. Never repeat existing entries verbatim."
 )
 
 
@@ -43,7 +54,10 @@ class DreamSession:
 class DreamResult:
     """Output of a single autoDream run."""
 
-    updated_memory: str
+    # Legacy free-form memory (kept for backward compat; prefer entries)
+    updated_memory: str = ""
+    # Structured entries from new schema-aware prompt (preferred)
+    entries: Optional[list[dict]] = None
     learnings: list[str] = field(default_factory=list)
     issues_detected: list[str] = field(default_factory=list)
     summary: str = ""
@@ -94,6 +108,7 @@ class AutoDreamBrain:
 
         return DreamResult(
             updated_memory=session.robot_memory,
+            entries=None,
             learnings=[],
             issues_detected=[],
             summary="autoDream brain unavailable — memory unchanged.",
@@ -102,6 +117,37 @@ class AutoDreamBrain:
     def _build_session_prompt(self, session: DreamSession) -> str:
         """Build the user-turn prompt from *session* data."""
         error_lines = "\n".join(session.session_logs[-50:]) if session.session_logs else "(none)"
+
+        # Format existing memory for context — support both structured and free-form
+        existing_memory = session.robot_memory
+        try:
+            import os
+            import tempfile
+
+            from castor.brain.memory_schema import (
+                apply_confidence_decay,
+                filter_for_context,
+                format_entries_for_context,
+                load_memory,
+            )
+
+            fd, tmp = tempfile.mkstemp(suffix=".md")
+            try:
+                with os.fdopen(fd, "w") as f:
+                    f.write(session.robot_memory)
+                mem = load_memory(tmp)
+                if mem.entries:
+                    mem = apply_confidence_decay(mem)
+                    eligible = filter_for_context(mem)
+                    existing_memory = format_entries_for_context(eligible)
+            finally:
+                try:
+                    os.unlink(tmp)
+                except Exception:
+                    pass
+        except Exception:
+            pass  # Fall back to raw text
+
         return (
             "<dream-session>\n"
             f"<date>{session.date}</date>\n"
@@ -109,12 +155,13 @@ class AutoDreamBrain:
             "<recent-errors>\n"
             f"{error_lines}\n"
             "</recent-errors>\n"
-            "<current-memory>\n"
-            f"{session.robot_memory}\n"
-            "</current-memory>\n"
+            "<existing-memory>\n"
+            f"{existing_memory}\n"
+            "</existing-memory>\n"
             "</dream-session>\n"
             "\n"
-            "Analyze the above and return updated robot memory + learnings as JSON."
+            "Return new or updated observations as structured JSON entries. "
+            "Do not repeat existing entries. Focus on what is new or changed."
         )
 
     def _parse_response(self, text: str) -> DreamResult | None:
@@ -134,8 +181,39 @@ class AutoDreamBrain:
         if not isinstance(data, dict):
             return None
 
-        updated_memory = data.get("updated_memory")
-        if not isinstance(updated_memory, str) or not updated_memory.strip():
+        # New structured format: entries list (preferred)
+        raw_entries = data.get("entries")
+        entries: list[dict] | None = None
+        if isinstance(raw_entries, list) and raw_entries:
+            validated = []
+            for e in raw_entries:
+                if not isinstance(e, dict):
+                    continue
+                text = e.get("text", "")
+                etype = e.get("type", "hardware_observation")
+                confidence = float(e.get("confidence", 0.7))
+                tags = e.get("tags", [])
+                if not isinstance(tags, list):
+                    tags = []
+                if text and isinstance(text, str):
+                    validated.append(
+                        {
+                            "type": etype,
+                            "text": str(text)[:500],
+                            "confidence": max(0.0, min(1.0, confidence)),
+                            "tags": [str(t) for t in tags if t],
+                        }
+                    )
+            if validated:
+                entries = validated
+
+        # Legacy format: updated_memory string (backward compat)
+        updated_memory = data.get("updated_memory", "")
+        if not isinstance(updated_memory, str):
+            updated_memory = ""
+
+        # Require at least one of entries or updated_memory
+        if entries is None and not updated_memory.strip():
             return None
 
         learnings = data.get("learnings", [])
@@ -152,6 +230,7 @@ class AutoDreamBrain:
 
         return DreamResult(
             updated_memory=updated_memory,
+            entries=entries,
             learnings=learnings,
             issues_detected=issues_detected,
             summary=summary,

--- a/castor/brain/autodream_runner.py
+++ b/castor/brain/autodream_runner.py
@@ -88,6 +88,81 @@ def _write_memory_atomic(content: str) -> None:
         raise
 
 
+def _write_structured_memory(new_entries: list[dict], date_str: str) -> None:
+    """Upsert new entries into the structured robot-memory.md via memory_schema."""
+    from datetime import datetime, timezone
+
+    from castor.brain.memory_schema import (
+        EntryType,
+        MemoryEntry,
+        apply_confidence_decay,
+        load_memory,
+        make_entry_id,
+        prune_entries,
+        save_memory,
+    )
+
+    mem = load_memory(str(MEMORY_FILE))
+    mem = apply_confidence_decay(mem)
+    mem.rrn = RRN if RRN != "unknown" else mem.rrn
+
+    existing_ids = {e.id for e in mem.entries}
+    existing_texts = {e.text.lower()[:80]: e for e in mem.entries}
+
+    now = datetime.now(timezone.utc)
+    added, reinforced = 0, 0
+
+    for raw in new_entries:
+        try:
+            etype = EntryType(raw.get("type", "hardware_observation"))
+        except ValueError:
+            etype = EntryType.HARDWARE_OBSERVATION
+
+        text = str(raw.get("text", ""))[:500]
+        confidence = float(raw.get("confidence", 0.7))
+        tags = list(raw.get("tags", []))
+        entry_id = make_entry_id(text, etype)
+
+        # Reinforce if text is very similar to an existing entry
+        key = text.lower()[:80]
+        if entry_id in existing_ids or key in existing_texts:
+            existing = existing_texts.get(key) or next(
+                (e for e in mem.entries if e.id == entry_id), None
+            )
+            if existing:
+                idx = mem.entries.index(existing)
+                mem.entries[idx] = existing.reinforce(nudge=0.1)
+                reinforced += 1
+                continue
+
+        # New entry
+        entry = MemoryEntry(
+            id=entry_id,
+            type=etype,
+            text=text,
+            confidence=confidence,
+            first_seen=now,
+            last_reinforced=now,
+            observation_count=1,
+            tags=tags,
+        )
+        mem.entries.append(entry)
+        existing_ids.add(entry_id)
+        existing_texts[key] = entry
+        added += 1
+
+    # Prune stale entries and save
+    mem, pruned = prune_entries(mem)
+    save_memory(mem, str(MEMORY_FILE))
+    logger.info(
+        "autoDream: structured memory updated — added=%d reinforced=%d pruned=%d total=%d",
+        added,
+        reinforced,
+        pruned,
+        len(mem.entries),
+    )
+
+
 def _append_dream_log(entry: dict) -> None:
     OPENCASTOR_DIR.mkdir(parents=True, exist_ok=True)
     with open(DREAM_LOG_FILE, "a", encoding="utf-8") as f:
@@ -160,10 +235,17 @@ def main() -> None:
     brain = AutoDreamBrain(provider=provider)
     result: DreamResult = brain.run(session)
 
-    # Write memory atomically
+    # Write memory — prefer structured entries, fall back to free-form text
     try:
-        _write_memory_atomic(result.updated_memory)
-        logger.info("autoDream: memory updated (%d chars)", len(result.updated_memory))
+        if result.entries:
+            _write_structured_memory(result.entries, date_str)
+        elif result.updated_memory:
+            _write_memory_atomic(result.updated_memory)
+            logger.info(
+                "autoDream: memory updated (free-form, %d chars)", len(result.updated_memory)
+            )
+        else:
+            logger.warning("autoDream: no memory output from brain — leaving unchanged")
     except Exception as exc:
         logger.error("autoDream: failed to write memory: %s", exc)
         sys.exit(1)

--- a/castor/cli.py
+++ b/castor/cli.py
@@ -1505,8 +1505,145 @@ def cmd_logs(args) -> None:
 
 
 def cmd_memory(args) -> None:
-    """castor memory — placeholder."""
-    print("castor memory: coming soon.")
+    """castor memory — show, prune, and manage robot operational memory."""
+    import os
+    from pathlib import Path
+
+    from castor.brain.memory_schema import (
+        CONFIDENCE_INJECT_MIN,
+        EntryType,
+        MemoryEntry,
+        apply_confidence_decay,
+        filter_for_context,
+        load_memory,
+        make_entry_id,
+        prune_entries,
+        save_memory,
+    )
+
+    memory_path = os.getenv(
+        "CASTOR_ROBOT_MEMORY_FILE",
+        str(Path.home() / ".opencastor" / "robot-memory.md"),
+    )
+    cmd = getattr(args, "memory_cmd", None) or "show"
+
+    if cmd == "show":
+        from datetime import datetime, timezone
+
+        mem = load_memory(memory_path)
+        mem = apply_confidence_decay(mem)
+        eligible = filter_for_context(mem)
+        all_entries = mem.entries
+
+        print(f"\n🧠 Robot Memory — {mem.rrn}")
+        print(f"   File: {memory_path}")
+        print(f"   Last updated: {mem.last_updated.strftime('%Y-%m-%d %H:%M UTC')}")
+        print(f"   Total entries: {len(all_entries)} ({len(eligible)} above inject threshold)\n")
+
+        if not all_entries:
+            print("  (no entries yet — run autoDream to populate)\n")
+            return
+
+        by_type: dict[str, list] = {}
+        for e in sorted(all_entries, key=lambda e: -e.confidence):
+            by_type.setdefault(e.type.value, []).append(e)
+
+        for type_name, entries in by_type.items():
+            print(f"  ── {type_name.upper().replace('_', ' ')} ──")
+            for e in entries:
+                conf_pct = int(e.confidence * 100)
+                if e.confidence >= 0.8:
+                    bar = "🔴"
+                elif e.confidence >= 0.5:
+                    bar = "🟡"
+                elif e.confidence >= CONFIDENCE_INJECT_MIN:
+                    bar = "🟢"
+                else:
+                    bar = "⚫"
+                days = (datetime.now(timezone.utc) - e.last_reinforced).days
+                injected = "✓" if e in eligible else "✗"
+                print(f"  {bar} [{conf_pct:3d}%] [inject:{injected}] {e.text}")
+                print(f"       id:{e.id} | obs:{e.observation_count}x | last:{days}d ago")
+            print()
+
+    elif cmd == "prune":
+        mem = load_memory(memory_path)
+        mem = apply_confidence_decay(mem)
+        threshold = float(getattr(args, "threshold", "0.10"))
+        pruned, count = prune_entries(mem, min_confidence=threshold)
+        dry = getattr(args, "dry_run", False)
+        if dry:
+            print(f"\nDRY RUN — would prune {count} entries below {threshold:.0%} confidence\n")
+            for e in mem.entries:
+                if e.confidence < threshold:
+                    print(f"  would remove: [{int(e.confidence * 100)}%] {e.text}")
+        else:
+            save_memory(pruned, memory_path)
+            print(f"✓ Pruned {count} entries below {threshold:.0%} confidence")
+
+    elif cmd == "add":
+        entry_type_str = getattr(args, "entry_type", "hardware_observation")
+        text = getattr(args, "text", "")
+        confidence = float(getattr(args, "confidence", "0.8"))
+        tags = (getattr(args, "tags", "") or "").split(",")
+        tags = [t.strip() for t in tags if t.strip()]
+
+        if not text:
+            print(
+                "\nUsage: castor memory add --text 'observation text' [--type TYPE] [--confidence 0.8]\n"
+            )
+            return
+
+        try:
+            entry_type = EntryType(entry_type_str)
+        except ValueError:
+            valid = [e.value for e in EntryType]
+            print(f"Invalid type '{entry_type_str}'. Valid: {', '.join(valid)}")
+            return
+
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        entry = MemoryEntry(
+            id=make_entry_id(text, entry_type),
+            type=entry_type,
+            text=text,
+            confidence=confidence,
+            first_seen=now,
+            last_reinforced=now,
+            observation_count=1,
+            tags=tags,
+        )
+        mem = load_memory(memory_path)
+        rrn = getattr(args, "rrn", None) or os.getenv("CASTOR_RRN", mem.rrn)
+        mem.rrn = rrn
+        mem.entries.append(entry)
+        save_memory(mem, memory_path)
+        print(f"✓ Added entry [{int(confidence * 100)}%] {entry.type.value}: {text}")
+        if tags:
+            print(f"  Tags: {', '.join(tags)}")
+
+    elif cmd == "decay":
+        mem = load_memory(memory_path)
+        original_confs = {e.id: e.confidence for e in mem.entries}
+        mem = apply_confidence_decay(mem)
+        save_memory(mem, memory_path)
+        changed = [
+            (e, original_confs[e.id])
+            for e in mem.entries
+            if abs(e.confidence - original_confs.get(e.id, e.confidence)) > 0.001
+        ]
+        print(f"✓ Applied confidence decay — {len(changed)} entries updated")
+        for e, old in changed[:10]:
+            print(f"  [{int(old * 100)}% → {int(e.confidence * 100)}%] {e.text[:60]}")
+
+    else:
+        print("\n  castor memory — robot operational memory management\n")
+        print("  Commands:")
+        print("    castor memory show              Show all entries with confidence")
+        print("    castor memory add --text '...'  Add a manual entry")
+        print("    castor memory prune             Remove entries below threshold")
+        print("    castor memory decay             Apply time-based confidence decay\n")
 
 
 def cmd_migrate(args) -> None:
@@ -6252,30 +6389,49 @@ def main() -> None:
     # castor memory
     p_memory = sub.add_parser(
         "memory",
-        help="Manage robot memory and episode consolidation",
+        help="Manage robot operational memory (robot-memory.md)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="Examples:\n  castor memory replay --since 2026-01-01 --dry-run",
+        epilog=(
+            "Examples:\n"
+            "  castor memory show\n"
+            "  castor memory add --text 'left wheel encoder intermittent' --type hardware_observation\n"
+            "  castor memory prune --threshold 0.15\n"
+            "  castor memory decay\n"
+        ),
     )
     memory_sub = p_memory.add_subparsers(dest="memory_cmd")
+    memory_sub.add_parser("show", help="Show all entries with confidence scores")
+    p_mem_add = memory_sub.add_parser("add", help="Manually add a memory entry")
+    p_mem_add.add_argument("--text", required=True, help="Observation text (max 500 chars)")
+    p_mem_add.add_argument(
+        "--type",
+        dest="entry_type",
+        default="hardware_observation",
+        choices=["hardware_observation", "environment_note", "behavior_pattern", "resolved"],
+        help="Entry type (default: hardware_observation)",
+    )
+    p_mem_add.add_argument(
+        "--confidence",
+        default="0.8",
+        help="Initial confidence 0.0–1.0 (default: 0.8)",
+    )
+    p_mem_add.add_argument("--tags", default="", help="Comma-separated tags")
+    p_mem_add.add_argument("--rrn", default=None, help="Robot RRN (default: CASTOR_RRN env)")
+    p_mem_prune = memory_sub.add_parser("prune", help="Remove entries below confidence threshold")
+    p_mem_prune.add_argument(
+        "--threshold", default="0.10", help="Min confidence to keep (default: 0.10)"
+    )
+    p_mem_prune.add_argument("--dry-run", action="store_true", help="Show what would be pruned")
+    memory_sub.add_parser("decay", help="Apply time-based confidence decay and save")
+    # Legacy: replay (kept for backward compat)
     p_mem_replay = memory_sub.add_parser(
         "replay", help="Replay historical episodes through updated consolidation pipeline"
     )
-    p_mem_replay.add_argument(
-        "--since",
-        default=None,
-        metavar="DATE",
-        help="Only replay episodes on/after this date (YYYY-MM-DD)",
-    )
-    p_mem_replay.add_argument("--episode-id", default=None, help="Replay a specific episode by ID")
-    p_mem_replay.add_argument(
-        "--episodes-dir", default=None, help="Path to L0-episodic/episodes/ directory"
-    )
-    p_mem_replay.add_argument(
-        "--dry-run", action="store_true", help="Simulate without writing changes"
-    )
-    p_mem_replay.add_argument(
-        "--verbose", "-v", action="store_true", help="Show each episode being replayed"
-    )
+    p_mem_replay.add_argument("--since", default=None, metavar="DATE")
+    p_mem_replay.add_argument("--episode-id", default=None)
+    p_mem_replay.add_argument("--episodes-dir", default=None)
+    p_mem_replay.add_argument("--dry-run", action="store_true")
+    p_mem_replay.add_argument("--verbose", "-v", action="store_true")
 
     # castor fleet
     p_fleet = sub.add_parser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencastor"
-version = "2026.4.1.0"
+version = "2026.4.2.0"
 description = "The Universal Runtime for Embodied AI"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_autodream.py
+++ b/tests/test_autodream.py
@@ -71,7 +71,7 @@ def test_build_session_prompt_includes_all_sections(sample_session):
     assert "<date>2026-04-01</date>" in prompt
     assert "<health>" in prompt
     assert "<recent-errors>" in prompt
-    assert "<current-memory>" in prompt
+    assert "<existing-memory>" in prompt
     assert "connection refused" in prompt
 
 


### PR DESCRIPTION
## v2026.4.2.0

### Structured Robot Memory
- `castor/brain/memory_schema.py`: `MemoryEntry` (typed, confidence-scored, time-decaying); `RobotMemory`; atomic load/save; filter/prune/format
- 17 tests

### `castor memory` CLI
```
castor memory show                          # 🔴🟡🟢 confidence bars
castor memory add --text '...' --type ...  # manual entry
castor memory prune [--threshold 0.15]     # remove stale entries
castor memory decay                         # apply time decay + save
```

### autoDream KAIROS v2
- New structured JSON prompt: LLM returns `entries[]` instead of free-form text
- `_write_structured_memory()`: upsert + reinforce + prune on each nightly run
- Session prompt shows existing memory in 🔴🟡🟢 format
- Full backward compat with legacy `updated_memory` format

**73 tests passing**