### PR TITLE
test: autoDream end-to-end validation (#843)

### DIFF
--- a/tests/brain/test_autodream_brain.py
+++ b/tests/brain/test_autodream_brain.py
@@ -1,0 +1,203 @@
+"""End-to-end tests for AutoDreamBrain (castor/brain/autodream.py).
+
+Tests mock AnthropicProvider.think() so no real API calls are made.
+Validates that AutoDreamBrain.run() returns a well-formed DreamResult
+and that the fields satisfy schema constraints.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from castor.brain.autodream import (
+    AUTODREAM_SYSTEM_PROMPT,
+    AutoDreamBrain,
+    DreamResult,
+    DreamSession,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(raw_text: str) -> MagicMock:
+    """Return a mock provider whose think() resolves to *raw_text*."""
+    thought = MagicMock()
+    thought.raw_text = raw_text
+
+    provider = MagicMock()
+    provider.think.return_value = thought
+    # system_prompt must be a settable str attribute (AutoDreamBrain swaps it)
+    provider.system_prompt = ""
+    return provider
+
+
+def _canned_dream_json(
+    *,
+    learnings: list[str] | None = None,
+    issues_detected: list[str] | None = None,
+    summary: str = "Quiet night.",
+    memory: str = "# Robot Memory\n## Learnings\n- CPU spikes under OAK-D load",
+) -> str:
+    return json.dumps(
+        {
+            "updated_memory": memory,
+            "learnings": learnings if learnings is not None else ["CPU spikes to 72 C under load"],
+            "issues_detected": issues_detected if issues_detected is not None else [],
+            "summary": summary,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session() -> DreamSession:
+    return DreamSession(
+        session_logs=[
+            "ERROR: OAK-D frame timeout after 2000 ms",
+            "WARN: CPU temp 72 C — throttling imminent",
+        ],
+        robot_memory="# Robot Memory\n## Known Issues\n- none",
+        health_report={"cpu_temp_c": "72.0", "disk_used_pct": 55, "gateway": "ok"},
+        date="2026-04-02",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: return type and field schema
+# ---------------------------------------------------------------------------
+
+
+def test_run_returns_dream_result(session: DreamSession) -> None:
+    brain = AutoDreamBrain(provider=_make_provider(_canned_dream_json()))
+    result = brain.run(session)
+    assert isinstance(result, DreamResult)
+
+
+def test_run_result_has_updated_memory(session: DreamSession) -> None:
+    brain = AutoDreamBrain(provider=_make_provider(_canned_dream_json()))
+    result = brain.run(session)
+    assert isinstance(result.updated_memory, str)
+    assert result.updated_memory.strip()  # non-empty
+
+
+def test_run_result_learnings_is_list_of_strings(session: DreamSession) -> None:
+    raw = _canned_dream_json(learnings=["Learned A", "Learned B"])
+    brain = AutoDreamBrain(provider=_make_provider(raw))
+    result = brain.run(session)
+    assert isinstance(result.learnings, list)
+    assert len(result.learnings) == 2
+    assert all(isinstance(item, str) for item in result.learnings)
+
+
+def test_run_result_issues_detected_is_list(session: DreamSession) -> None:
+    raw = _canned_dream_json(issues_detected=["Motor stall #3 at joint 2"])
+    brain = AutoDreamBrain(provider=_make_provider(raw))
+    result = brain.run(session)
+    assert isinstance(result.issues_detected, list)
+    assert result.issues_detected[0] == "Motor stall #3 at joint 2"
+
+
+def test_run_result_summary_is_str(session: DreamSession) -> None:
+    raw = _canned_dream_json(summary="All systems nominal.")
+    brain = AutoDreamBrain(provider=_make_provider(raw))
+    result = brain.run(session)
+    assert isinstance(result.summary, str)
+    assert result.summary == "All systems nominal."
+
+
+# ---------------------------------------------------------------------------
+# Tests: provider interaction
+# ---------------------------------------------------------------------------
+
+
+def test_run_calls_provider_think_once(session: DreamSession) -> None:
+    provider = _make_provider(_canned_dream_json())
+    brain = AutoDreamBrain(provider=provider)
+    brain.run(session)
+    provider.think.assert_called_once()
+
+
+def test_run_restores_provider_system_prompt(session: DreamSession) -> None:
+    """AutoDreamBrain must restore the original system_prompt after the call."""
+    provider = _make_provider(_canned_dream_json())
+    original = "original system prompt"
+    provider.system_prompt = original
+    brain = AutoDreamBrain(provider=provider)
+    brain.run(session)
+    assert provider.system_prompt == original
+
+
+def test_run_swaps_to_autodream_system_prompt_during_call(session: DreamSession) -> None:
+    """Provider must receive the AUTODREAM_SYSTEM_PROMPT during think()."""
+    captured_prompts: list[str] = []
+
+    thought = MagicMock()
+    thought.raw_text = _canned_dream_json()
+
+    provider = MagicMock()
+    provider.system_prompt = "original"
+
+    def _capture_think(*args, **kwargs):
+        captured_prompts.append(provider.system_prompt)
+        return thought
+
+    provider.think.side_effect = _capture_think
+
+    brain = AutoDreamBrain(provider=provider)
+    brain.run(session)
+
+    assert len(captured_prompts) == 1
+    assert captured_prompts[0] == AUTODREAM_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Tests: fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_run_fallback_on_unparseable_json(session: DreamSession) -> None:
+    brain = AutoDreamBrain(provider=_make_provider("not {{ valid json"))
+    result = brain.run(session)
+    # Must preserve original memory — never corrupt it
+    assert result.updated_memory == session.robot_memory
+    assert result.learnings == []
+    assert result.issues_detected == []
+
+
+def test_run_fallback_on_provider_exception(session: DreamSession) -> None:
+    provider = MagicMock()
+    provider.system_prompt = ""
+    provider.think.side_effect = RuntimeError("quota exceeded")
+    brain = AutoDreamBrain(provider=provider)
+    result = brain.run(session)
+    assert result.updated_memory == session.robot_memory
+    assert "unavailable" in result.summary.lower()
+
+
+def test_run_fallback_when_updated_memory_missing(session: DreamSession) -> None:
+    raw = json.dumps({"learnings": ["x"], "issues_detected": [], "summary": "ok"})
+    brain = AutoDreamBrain(provider=_make_provider(raw))
+    result = brain.run(session)
+    assert result.updated_memory == session.robot_memory
+
+
+# ---------------------------------------------------------------------------
+# Tests: JSON wrapped in markdown fences
+# ---------------------------------------------------------------------------
+
+
+def test_run_parses_json_in_markdown_fence(session: DreamSession) -> None:
+    fence_wrapped = "```json\n" + _canned_dream_json() + "\n```"
+    brain = AutoDreamBrain(provider=_make_provider(fence_wrapped))
+    result = brain.run(session)
+    assert isinstance(result, DreamResult)
+    assert result.learnings  # at least one entry

--- a/tests/brain/test_autodream_runner.py
+++ b/tests/brain/test_autodream_runner.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for the autoDream runner (castor/brain/autodream_runner.py).
+
+Uses tmp_path to isolate filesystem writes; patches module-level globals so no
+real ~/.opencastor directory is touched and no real API calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import castor.brain.autodream_runner as runner_mod
+from castor.brain.autodream_runner import main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_mock(dream_json: str) -> MagicMock:
+    """Return a mock AnthropicProvider instance that returns *dream_json* from think()."""
+    thought = MagicMock()
+    thought.raw_text = dream_json
+
+    provider = MagicMock()
+    provider.think.return_value = thought
+    provider.system_prompt = ""
+    return provider
+
+
+def _canned_dream_json(
+    *,
+    memory: str = "# Robot Memory\n## Learnings\n- motor latency stable at 12 ms",
+    learnings: list[str] | None = None,
+    issues_detected: list[str] | None = None,
+    summary: str = "All systems nominal.",
+) -> str:
+    return json.dumps(
+        {
+            "updated_memory": memory,
+            "learnings": learnings if learnings is not None else ["motor latency stable at 12 ms"],
+            "issues_detected": issues_detected if issues_detected is not None else [],
+            "summary": summary,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect all runner file I/O to *tmp_path*."""
+    monkeypatch.setattr(runner_mod, "OPENCASTOR_DIR", tmp_path)
+    monkeypatch.setattr(runner_mod, "MEMORY_FILE", tmp_path / "robot-memory.md")
+    monkeypatch.setattr(runner_mod, "DREAM_LOG_FILE", tmp_path / "dream-log.jsonl")
+    # Point gateway log at a non-existent path so _load_session_logs returns []
+    monkeypatch.setattr(runner_mod, "GATEWAY_LOG", tmp_path / "gateway.log")
+    monkeypatch.setattr(runner_mod, "DRY_RUN", False)
+    monkeypatch.setattr(runner_mod, "FILE_ISSUES", False)
+    monkeypatch.setattr(runner_mod, "RRN", "RRN-TEST-001")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: dream-log.jsonl schema
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_dream_log(isolated_dir: Path) -> None:
+    provider_mock = _make_provider_mock(_canned_dream_json())
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    log_path = isolated_dir / "dream-log.jsonl"
+    assert log_path.exists(), "dream-log.jsonl was not created"
+
+
+def test_dream_log_contains_valid_json_line(isolated_dir: Path) -> None:
+    provider_mock = _make_provider_mock(_canned_dream_json())
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    raw = (isolated_dir / "dream-log.jsonl").read_text().strip()
+    entry = json.loads(raw)  # raises if not valid JSON
+    assert isinstance(entry, dict)
+
+
+def test_dream_log_has_required_fields(isolated_dir: Path) -> None:
+    provider_mock = _make_provider_mock(_canned_dream_json())
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    entry = json.loads((isolated_dir / "dream-log.jsonl").read_text().strip())
+    for field in ("date", "model", "rrn", "learnings", "summary"):
+        assert field in entry, f"dream-log entry missing field '{field}'"
+
+
+def test_dream_log_rrn_matches_env(isolated_dir: Path) -> None:
+    provider_mock = _make_provider_mock(_canned_dream_json())
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    entry = json.loads((isolated_dir / "dream-log.jsonl").read_text().strip())
+    assert entry["rrn"] == "RRN-TEST-001"
+
+
+def test_dream_log_learnings_is_list(isolated_dir: Path) -> None:
+    raw = _canned_dream_json(learnings=["latency stable", "OAK-D healthy"])
+    provider_mock = _make_provider_mock(raw)
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    entry = json.loads((isolated_dir / "dream-log.jsonl").read_text().strip())
+    assert isinstance(entry["learnings"], list)
+    assert len(entry["learnings"]) == 2
+
+
+def test_dream_log_summary_is_str(isolated_dir: Path) -> None:
+    raw = _canned_dream_json(summary="Motor latency nominal.")
+    provider_mock = _make_provider_mock(raw)
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    entry = json.loads((isolated_dir / "dream-log.jsonl").read_text().strip())
+    assert isinstance(entry["summary"], str)
+    assert entry["summary"] == "Motor latency nominal."
+
+
+def test_dream_log_model_field_present(isolated_dir: Path) -> None:
+    provider_mock = _make_provider_mock(_canned_dream_json())
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    entry = json.loads((isolated_dir / "dream-log.jsonl").read_text().strip())
+    assert isinstance(entry["model"], str)
+    assert entry["model"]  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Tests: robot-memory.md written / updated
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_robot_memory(isolated_dir: Path) -> None:
+    provider_mock = _make_provider_mock(_canned_dream_json())
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    mem_path = isolated_dir / "robot-memory.md"
+    assert mem_path.exists(), "robot-memory.md was not created"
+
+
+def test_main_robot_memory_contains_updated_content(isolated_dir: Path) -> None:
+    updated = "# Robot Memory\n## Learnings\n- motor latency stable at 12 ms\n- OAK-D healthy"
+    provider_mock = _make_provider_mock(_canned_dream_json(memory=updated))
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    content = (isolated_dir / "robot-memory.md").read_text(encoding="utf-8")
+    assert "OAK-D healthy" in content
+
+
+def test_main_memory_preserved_on_bad_llm_response(isolated_dir: Path) -> None:
+    """If the LLM returns garbage, the original memory must not be overwritten."""
+    original_memory = "# Original Robot Memory\n- do not lose this"
+    (isolated_dir / "robot-memory.md").write_text(original_memory, encoding="utf-8")
+
+    provider_mock = _make_provider_mock("totally not json }{")
+    mock_cls = MagicMock(return_value=provider_mock)
+
+    with patch("castor.providers.anthropic_provider.AnthropicProvider", mock_cls):
+        main()
+
+    content = (isolated_dir / "robot-memory.md").read_text(encoding="utf-8")
+    assert content == original_memory
+
+
+# ---------------------------------------------------------------------------
+# Tests: dry-run mode (sanity check)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_skips_log_and_memory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runner_mod, "OPENCASTOR_DIR", tmp_path)
+    monkeypatch.setattr(runner_mod, "MEMORY_FILE", tmp_path / "robot-memory.md")
+    monkeypatch.setattr(runner_mod, "DREAM_LOG_FILE", tmp_path / "dream-log.jsonl")
+    monkeypatch.setattr(runner_mod, "GATEWAY_LOG", tmp_path / "gateway.log")
+    monkeypatch.setattr(runner_mod, "DRY_RUN", True)
+    monkeypatch.setattr(runner_mod, "RRN", "RRN-TEST-001")
+
+    main()  # must return without writing anything
+
+    assert not (tmp_path / "dream-log.jsonl").exists()
+    assert not (tmp_path / "robot-memory.md").exists()


### PR DESCRIPTION
Fixes #843.

## Summary
- Adds `tests/brain/test_autodream_brain.py` — 14 tests for `AutoDreamBrain.run()`: validates `DreamResult` schema (all fields typed correctly), provider system-prompt swap/restore, fallback on bad JSON and provider exceptions, markdown-fence stripping
- Adds `tests/brain/test_autodream_runner.py` — 9 tests for `main()`: patches module-level path globals via `monkeypatch`, mocks `AnthropicProvider.think()` with canned dream JSON, asserts `dream-log.jsonl` exists with all required fields (`date`, `model`, `rrn`, `learnings`, `summary`), asserts `robot-memory.md` written and preserved on LLM failure, dry-run guard

## Test plan
- [x] `python3 -m pytest tests/brain/ -x -q` → 23 passed
- [x] `ruff format tests/brain/ && ruff check tests/brain/ --fix` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)