### PR TITLE
feat: enrich autoDream session context (closes #846)

### DIFF
--- a/castor/brain/autodream.py
+++ b/castor/brain/autodream.py
@@ -48,6 +48,9 @@ class DreamSession:
     robot_memory: str
     health_report: dict
     date: str
+    recent_commits: list[str] = field(default_factory=list)  # last 5 git commits
+    bridge_log_tail: list[str] = field(default_factory=list)  # last 20 lines of bridge log
+    cron_outcomes: list[str] = field(default_factory=list)  # last 3 dream-log.jsonl summaries
 
 
 @dataclass
@@ -148,6 +151,10 @@ class AutoDreamBrain:
         except Exception:
             pass  # Fall back to raw text
 
+        commits_text = "\n".join(session.recent_commits) if session.recent_commits else "(none)"
+        bridge_text = "\n".join(session.bridge_log_tail) if session.bridge_log_tail else "(none)"
+        outcomes_text = "\n".join(session.cron_outcomes) if session.cron_outcomes else "(none)"
+
         return (
             "<dream-session>\n"
             f"<date>{session.date}</date>\n"
@@ -155,6 +162,15 @@ class AutoDreamBrain:
             "<recent-errors>\n"
             f"{error_lines}\n"
             "</recent-errors>\n"
+            "<recent-code-changes>\n"
+            f"{commits_text}\n"
+            "</recent-code-changes>\n"
+            "<bridge-activity>\n"
+            f"{bridge_text}\n"
+            "</bridge-activity>\n"
+            "<recent-dream-outcomes>\n"
+            f"{outcomes_text}\n"
+            "</recent-dream-outcomes>\n"
             "<existing-memory>\n"
             f"{existing_memory}\n"
             "</existing-memory>\n"

--- a/castor/brain/autodream_runner.py
+++ b/castor/brain/autodream_runner.py
@@ -43,6 +43,56 @@ DREAM_LOG_FILE = OPENCASTOR_DIR / "dream-log.jsonl"
 GATEWAY_LOG = Path(os.getenv("CASTOR_GATEWAY_LOG", "/tmp/castor-gateway.log"))
 
 
+def _load_recent_commits() -> list[str]:
+    """Return last 5 git commit oneline summaries from OPENCASTOR_DIR."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(OPENCASTOR_DIR), "log", "--oneline", "-5"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = result.stdout.strip().splitlines()
+        return [ln.strip() for ln in lines if ln.strip()]
+    except Exception:
+        return []
+
+
+def _load_bridge_log_tail(max_lines: int = 20) -> list[str]:
+    """Return the last *max_lines* lines of /tmp/castor-bridge.log (if it exists)."""
+    bridge_log = Path("/tmp/castor-bridge.log")
+    try:
+        lines = bridge_log.read_text(encoding="utf-8", errors="replace").splitlines()
+        return [ln.strip() for ln in lines[-max_lines:] if ln.strip()]
+    except Exception:
+        return []
+
+
+def _load_cron_outcomes(max_entries: int = 3) -> list[str]:
+    """Return the *max_entries* most recent dream-log.jsonl 'summary' values."""
+    try:
+        lines = DREAM_LOG_FILE.read_text(encoding="utf-8").splitlines()
+        summaries = []
+        for raw in reversed(lines):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                entry = json.loads(raw)
+                summary = entry.get("summary", "")
+                if summary:
+                    summaries.append(summary)
+            except Exception:
+                continue
+            if len(summaries) >= max_entries:
+                break
+        return list(reversed(summaries))
+    except Exception:
+        return []
+
+
 def _load_health_report(date_str: str) -> dict:
     path = OPENCASTOR_DIR / f"health-{date_str.replace('-', '')}.json"
     try:
@@ -210,12 +260,18 @@ def main() -> None:
     health = _load_health_report(date_str)
     logs = _load_session_logs()
     memory = _load_memory()
+    recent_commits = _load_recent_commits()
+    bridge_log_tail = _load_bridge_log_tail()
+    cron_outcomes = _load_cron_outcomes()
 
     session = DreamSession(
         session_logs=logs,
         robot_memory=memory,
         health_report=health,
         date=date_str,
+        recent_commits=recent_commits,
+        bridge_log_tail=bridge_log_tail,
+        cron_outcomes=cron_outcomes,
     )
 
     if DRY_RUN:

--- a/tests/brain/test_autodream_context.py
+++ b/tests/brain/test_autodream_context.py
@@ -1,0 +1,284 @@
+"""Tests for autoDream enriched session context (issue #846).
+
+Covers:
+  - DreamSession accepts new fields (recent_commits, bridge_log_tail, cron_outcomes)
+  - DreamSession fields default to empty lists (backward compat)
+  - _build_session_prompt() includes new sections in output
+  - _load_recent_commits() returns lines from git log stdout
+  - _load_bridge_log_tail() reads last 20 lines of bridge log
+  - _load_cron_outcomes() extracts 'summary' from last 3 dream-log.jsonl entries
+  - main() passes new fields into DreamSession
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── DreamSession defaults ─────────────────────────────────────────────────────
+
+
+def test_dream_session_new_fields_default_to_empty_lists():
+    """New fields must default to empty list — keeps existing callers working."""
+    from castor.brain.autodream import DreamSession
+
+    s = DreamSession(session_logs=[], robot_memory="", health_report={}, date="2026-04-01")
+    assert s.recent_commits == []
+    assert s.bridge_log_tail == []
+    assert s.cron_outcomes == []
+
+
+def test_dream_session_new_fields_accept_values():
+    from castor.brain.autodream import DreamSession
+
+    s = DreamSession(
+        session_logs=[],
+        robot_memory="",
+        health_report={},
+        date="2026-04-01",
+        recent_commits=["abc1234 fix: something"],
+        bridge_log_tail=["INFO bridge connected"],
+        cron_outcomes=["all clear"],
+    )
+    assert s.recent_commits == ["abc1234 fix: something"]
+    assert s.bridge_log_tail == ["INFO bridge connected"]
+    assert s.cron_outcomes == ["all clear"]
+
+
+# ── _build_session_prompt includes new sections ───────────────────────────────
+
+
+def _make_brain():
+    from unittest.mock import MagicMock
+
+    from castor.brain.autodream import AutoDreamBrain
+
+    return AutoDreamBrain(provider=MagicMock())
+
+
+def test_build_session_prompt_includes_recent_code_changes():
+    from castor.brain.autodream import DreamSession
+
+    brain = _make_brain()
+    s = DreamSession(
+        session_logs=[],
+        robot_memory="",
+        health_report={},
+        date="2026-04-01",
+        recent_commits=["abc1234 feat: add widget"],
+    )
+    prompt = brain._build_session_prompt(s)
+    assert "<recent-code-changes>" in prompt
+    assert "abc1234 feat: add widget" in prompt
+
+
+def test_build_session_prompt_includes_bridge_activity():
+    from castor.brain.autodream import DreamSession
+
+    brain = _make_brain()
+    s = DreamSession(
+        session_logs=[],
+        robot_memory="",
+        health_report={},
+        date="2026-04-01",
+        bridge_log_tail=["INFO heartbeat ok", "WARN slow response"],
+    )
+    prompt = brain._build_session_prompt(s)
+    assert "<bridge-activity>" in prompt
+    assert "INFO heartbeat ok" in prompt
+    assert "WARN slow response" in prompt
+
+
+def test_build_session_prompt_includes_recent_dream_outcomes():
+    from castor.brain.autodream import DreamSession
+
+    brain = _make_brain()
+    s = DreamSession(
+        session_logs=[],
+        robot_memory="",
+        health_report={},
+        date="2026-04-01",
+        cron_outcomes=["no new learnings", "motor jitter noted"],
+    )
+    prompt = brain._build_session_prompt(s)
+    assert "<recent-dream-outcomes>" in prompt
+    assert "no new learnings" in prompt
+    assert "motor jitter noted" in prompt
+
+
+def test_build_session_prompt_empty_fields_show_none_placeholder():
+    """When new fields are empty, prompt should show '(none)' placeholders."""
+    from castor.brain.autodream import DreamSession
+
+    brain = _make_brain()
+    s = DreamSession(session_logs=[], robot_memory="", health_report={}, date="2026-04-01")
+    prompt = brain._build_session_prompt(s)
+    # All three sections should still appear but with (none)
+    assert "<recent-code-changes>" in prompt
+    assert "<bridge-activity>" in prompt
+    assert "<recent-dream-outcomes>" in prompt
+    assert prompt.count("(none)") >= 3
+
+
+# ── _load_recent_commits ──────────────────────────────────────────────────────
+
+
+def test_load_recent_commits_parses_git_output(monkeypatch):
+    import castor.brain.autodream_runner as runner_mod
+
+    fake_stdout = "abc1234 feat: add thing\ndef5678 fix: repair bug\n"
+    mock_result = MagicMock(stdout=fake_stdout)
+
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        commits = runner_mod._load_recent_commits()
+
+    assert commits == ["abc1234 feat: add thing", "def5678 fix: repair bug"]
+    cmd = mock_run.call_args.args[0]
+    assert "log" in cmd
+    assert "--oneline" in cmd
+    assert "-5" in cmd
+
+
+def test_load_recent_commits_returns_empty_on_error(monkeypatch):
+    import castor.brain.autodream_runner as runner_mod
+
+    with patch("subprocess.run", side_effect=FileNotFoundError("git not found")):
+        commits = runner_mod._load_recent_commits()
+
+    assert commits == []
+
+
+# ── _load_bridge_log_tail ─────────────────────────────────────────────────────
+
+
+def test_load_bridge_log_tail_reads_last_20_lines(tmp_path):
+    import castor.brain.autodream_runner as runner_mod
+
+    bridge_log = tmp_path / "castor-bridge.log"
+    all_lines = [f"line {i}" for i in range(30)]
+    bridge_log.write_text("\n".join(all_lines) + "\n")
+
+    with patch("castor.brain.autodream_runner.Path") as MockPath:
+        # Only intercept the bridge log path; let other Path calls pass through
+        real_path = Path
+
+        def path_side_effect(arg):
+            if arg == "/tmp/castor-bridge.log":
+                return bridge_log
+            return real_path(arg)
+
+        MockPath.side_effect = path_side_effect
+        tail = runner_mod._load_bridge_log_tail()
+
+    assert len(tail) == 20
+    assert tail[0] == "line 10"
+    assert tail[-1] == "line 29"
+
+
+def test_load_bridge_log_tail_returns_empty_when_missing():
+    import castor.brain.autodream_runner as runner_mod
+
+    with patch("castor.brain.autodream_runner.Path") as MockPath:
+        real_path = Path
+
+        def path_side_effect(arg):
+            if arg == "/tmp/castor-bridge.log":
+                missing = MagicMock(spec=Path)
+                missing.read_text.side_effect = FileNotFoundError
+                return missing
+            return real_path(arg)
+
+        MockPath.side_effect = path_side_effect
+        tail = runner_mod._load_bridge_log_tail()
+
+    assert tail == []
+
+
+# ── _load_cron_outcomes ───────────────────────────────────────────────────────
+
+
+def test_load_cron_outcomes_extracts_last_3_summaries(tmp_path, monkeypatch):
+    import castor.brain.autodream_runner as runner_mod
+
+    dream_log = tmp_path / "dream-log.jsonl"
+    entries = [
+        {"date": f"2026-04-0{i}", "summary": f"summary {i}"}
+        for i in range(1, 6)
+    ]
+    dream_log.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    monkeypatch.setattr(runner_mod, "DREAM_LOG_FILE", dream_log)
+
+    outcomes = runner_mod._load_cron_outcomes()
+
+    assert outcomes == ["summary 3", "summary 4", "summary 5"]
+
+
+def test_load_cron_outcomes_skips_entries_without_summary(tmp_path, monkeypatch):
+    import castor.brain.autodream_runner as runner_mod
+
+    dream_log = tmp_path / "dream-log.jsonl"
+    entries = [
+        {"date": "2026-04-01", "summary": ""},
+        {"date": "2026-04-02"},
+        {"date": "2026-04-03", "summary": "good run"},
+    ]
+    dream_log.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    monkeypatch.setattr(runner_mod, "DREAM_LOG_FILE", dream_log)
+
+    outcomes = runner_mod._load_cron_outcomes()
+
+    assert outcomes == ["good run"]
+
+
+def test_load_cron_outcomes_returns_empty_when_missing(tmp_path, monkeypatch):
+    import castor.brain.autodream_runner as runner_mod
+
+    monkeypatch.setattr(runner_mod, "DREAM_LOG_FILE", tmp_path / "nonexistent.jsonl")
+    assert runner_mod._load_cron_outcomes() == []
+
+
+# ── main() passes new fields into DreamSession ───────────────────────────────
+
+
+def test_main_passes_enriched_context_to_session(tmp_path, monkeypatch):
+    """main() must pass recent_commits, bridge_log_tail, cron_outcomes to DreamSession."""
+    import castor.brain.autodream_runner as runner_mod
+
+    monkeypatch.setattr(runner_mod, "DRY_RUN", False)
+    monkeypatch.setattr(runner_mod, "OPENCASTOR_DIR", tmp_path)
+    monkeypatch.setattr(runner_mod, "MEMORY_FILE", tmp_path / "robot-memory.md")
+    monkeypatch.setattr(runner_mod, "DREAM_LOG_FILE", tmp_path / "dream-log.jsonl")
+    monkeypatch.setattr(runner_mod, "GATEWAY_LOG", tmp_path / "gateway.log")
+
+    captured_session: list = []
+
+    def fake_run(session):
+        captured_session.append(session)
+        from castor.brain.autodream import DreamResult
+        return DreamResult(updated_memory="ok", summary="done")
+
+    mock_brain = MagicMock()
+    mock_brain.run.side_effect = fake_run
+
+    with patch(
+        "castor.providers.anthropic_provider.AnthropicProvider", return_value=MagicMock()
+    ), patch(
+        "castor.brain.autodream_runner.AutoDreamBrain", return_value=mock_brain
+    ), patch(
+        "castor.brain.autodream_runner._load_recent_commits", return_value=["abc fix"]
+    ), patch(
+        "castor.brain.autodream_runner._load_bridge_log_tail", return_value=["INFO ok"]
+    ), patch(
+        "castor.brain.autodream_runner._load_cron_outcomes", return_value=["prev summary"]
+    ):
+        runner_mod.main()
+
+    assert len(captured_session) == 1
+    s = captured_session[0]
+    assert s.recent_commits == ["abc fix"]
+    assert s.bridge_log_tail == ["INFO ok"]
+    assert s.cron_outcomes == ["prev summary"]


### PR DESCRIPTION
## Summary

- **DreamSession** gets three new optional fields (`recent_commits`, `bridge_log_tail`, `cron_outcomes`) with empty-list defaults — fully backward compatible
- **autodream_runner** populates them before calling `brain.run()`:
  - `_load_recent_commits()` — runs `git log --oneline -5` in `OPENCASTOR_DIR`
  - `_load_bridge_log_tail()` — last 20 lines of `/tmp/castor-bridge.log` (silent if absent)
  - `_load_cron_outcomes()` — last 3 `summary` values from `dream-log.jsonl` (skips empty)
- **`_build_session_prompt()`** emits three new XML sections so the LLM sees richer context on every nightly run:
  - `<recent-code-changes>` — what changed in code since last session
  - `<bridge-activity>` — real-time bridge chatter, not just filtered error lines
  - `<recent-dream-outcomes>` — what prior dream sessions concluded

## Test plan

- [ ] `python -m pytest tests/brain/ -x -q` → 19 passed (14 new tests in `test_autodream_context.py`)
- [ ] `python -m ruff check castor/brain/` → no errors
- [ ] Verify `DreamSession` instantiation without new fields still works (backward compat test included)
- [ ] Verify empty fields produce `(none)` placeholders in prompt (test included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)