### PR TITLE
feat: inject post-compaction continuation message — closes #848

### DIFF
--- a/castor/context.py
+++ b/castor/context.py
@@ -58,6 +58,7 @@ class BuiltContext:
     messages: list[dict]
     token_estimate: int
     was_compacted: bool = False
+    compact_summary: str = ""
     skill_injected: Optional[str] = None
     rag_chunks: int = 0
     telemetry_injected: bool = False
@@ -173,6 +174,7 @@ class ContextBuilder:
 
         # 9. Compact if needed
         was_compacted = False
+        compact_summary = ""
         if self._context_budget > 1.0:
             # Absolute token count (e.g. 8192)
             budget_tokens = int(self._context_budget)
@@ -180,7 +182,9 @@ class ContextBuilder:
             # Ratio of model context limit (e.g. 0.8)
             budget_tokens = int(self._context_limit * self._context_budget)
         if token_estimate > budget_tokens and len(messages) > 4:
-            messages, was_compacted = await self._compact_history(messages, budget_tokens)
+            messages, was_compacted, compact_summary = await self._compact_history(
+                messages, budget_tokens
+            )
             token_estimate = self._estimate_tokens(system_prompt, messages)
 
         logger.debug(
@@ -197,6 +201,7 @@ class ContextBuilder:
             messages=messages,
             token_estimate=token_estimate,
             was_compacted=was_compacted,
+            compact_summary=compact_summary,
             skill_injected=skill_injected,
             rag_chunks=rag_chunks,
             telemetry_injected=telemetry_injected,
@@ -379,11 +384,11 @@ class ContextBuilder:
 
     async def _compact_history(
         self, messages: list[dict], budget_tokens: int
-    ) -> tuple[list[dict], bool]:
+    ) -> tuple[list[dict], bool, str]:
         """Summarise the oldest 50% of messages using a cheap model.
 
-        Returns (compacted_messages, True).  Falls back to simple truncation
-        if no provider is available for summarisation.
+        Returns (compacted_messages, True, summary_text).  Falls back to
+        simple truncation if no provider is available for summarisation.
         """
         try:
             mid = len(messages) // 2
@@ -396,11 +401,11 @@ class ContextBuilder:
                 *recent_messages,
             ]
             logger.info("Context compacted: %d → %d messages", len(messages), len(compacted))
-            return compacted, True
+            return compacted, True, summary
         except Exception as exc:
             logger.warning("Compaction failed, falling back to truncation: %s", exc)
             # Simple truncation: keep last 20 messages
-            return messages[-20:], True
+            return messages[-20:], True, ""
 
     async def _summarise_messages(self, messages: list[dict]) -> str:
         """Summarise a list of messages using the configured provider."""

--- a/castor/harness.py
+++ b/castor/harness.py
@@ -591,6 +591,15 @@ class AgentHarness:
         builder = self._get_context_builder()
         built: BuiltContext = await builder.build(ctx, history=[])
 
+        # 1a. Post-compaction continuation — prevents cold-start recap turns
+        if built.was_compacted and built.compact_summary:
+            from castor.brain.compaction import build_continuation_message
+
+            suppress = bool(ctx.mission_state.get("autonomous"))
+            built.messages.insert(
+                0, build_continuation_message(built.compact_summary, suppress_follow_up=suppress)
+            )
+
         # 2. Run pre-turn hooks
         for hook in self.hooks:
             span_name = f"hook.pre_turn.{type(hook).__name__}"

--- a/castor/harness/core.py
+++ b/castor/harness/core.py
@@ -653,6 +653,15 @@ class AgentHarness:
         builder = self._get_context_builder()
         built: BuiltContext = await builder.build(ctx, history=[])
 
+        # 1a. Post-compaction continuation — prevents cold-start recap turns
+        if built.was_compacted and built.compact_summary:
+            from castor.brain.compaction import build_continuation_message
+
+            suppress = bool(ctx.mission_state.get("autonomous"))
+            built.messages.insert(
+                0, build_continuation_message(built.compact_summary, suppress_follow_up=suppress)
+            )
+
         # 1b. Apply execution profile overrides ($deep / $quick)
         _profile_max_turns: Optional[int] = None
         if ctx.profile is not None:

--- a/tests/test_post_compaction_continuation.py
+++ b/tests/test_post_compaction_continuation.py
@@ -1,0 +1,215 @@
+"""Tests for post-compaction continuation injection in the harness pipeline.
+
+Verifies that after ContextBuilder.build() fires compaction, the harness
+inserts a system continuation message as the first message in the turn —
+preventing the cold-start recap turns described in issue #848.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from castor.context import BuiltContext
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_built_context(was_compacted: bool, compact_summary: str = "") -> BuiltContext:
+    return BuiltContext(
+        system_prompt="You are a robot.",
+        messages=[{"role": "user", "content": "do the thing"}],
+        token_estimate=100,
+        was_compacted=was_compacted,
+        compact_summary=compact_summary,
+    )
+
+
+# ── 1. BuiltContext carries compact_summary ───────────────────────────────────
+
+
+def test_built_context_has_compact_summary_field():
+    ctx = _make_built_context(was_compacted=True, compact_summary="robot drove to waypoint A")
+    assert ctx.compact_summary == "robot drove to waypoint A"
+    assert ctx.was_compacted is True
+
+
+def test_built_context_compact_summary_default_empty():
+    ctx = _make_built_context(was_compacted=False)
+    assert ctx.compact_summary == ""
+
+
+# ── 2. _compact_history returns summary text ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_compact_history_returns_summary_text():
+    from castor.context import ContextBuilder
+
+    builder = ContextBuilder()
+
+    with patch.object(builder, "_summarise_messages", new=AsyncMock(return_value="test summary")):
+        messages = [{"role": "user", "content": f"msg{i}"} for i in range(10)]
+        compacted, was_compacted, summary = await builder._compact_history(messages, budget_tokens=1)
+
+    assert was_compacted is True
+    assert summary == "test summary"
+    # Summary message is prepended in the compacted list
+    assert compacted[0]["role"] == "system"
+    assert "test summary" in compacted[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_compact_history_fallback_returns_empty_summary():
+    from castor.context import ContextBuilder
+
+    builder = ContextBuilder()
+
+    with patch.object(
+        builder,
+        "_summarise_messages",
+        new=AsyncMock(side_effect=RuntimeError("no provider")),
+    ):
+        messages = [{"role": "user", "content": f"msg{i}"} for i in range(10)]
+        compacted, was_compacted, summary = await builder._compact_history(messages, budget_tokens=1)
+
+    assert was_compacted is True
+    assert summary == ""  # fallback returns empty string
+
+
+# ── 3. Harness injects continuation when compacted ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_harness_injects_continuation_on_compaction():
+    """When build() returns was_compacted=True + compact_summary, the harness
+    inserts a system continuation message as the first message."""
+    from castor.harness.core import AgentHarness, HarnessContext
+
+    harness = AgentHarness.__new__(AgentHarness)
+    harness.hooks = []
+    harness.span_tracer = None
+
+    built = _make_built_context(was_compacted=True, compact_summary="robot navigated to zone B")
+
+    ctx = HarnessContext(
+        instruction="continue patrol",
+        mission_state={},
+    )
+
+    captured_messages: list = []
+
+    async def fake_tool_loop(ctx, built, **kwargs):
+        captured_messages.extend(built.messages)
+        mock_thought = MagicMock()
+        mock_thought.raw_text = "ok"
+        return mock_thought, [], 1
+
+    with (
+        patch.object(harness, "_get_context_builder") as mock_builder_factory,
+        patch.object(harness, "_tool_loop", new=fake_tool_loop),
+        patch.object(harness, "_log_trajectory", new=AsyncMock()),
+        patch("castor.harness.core.asyncio.ensure_future"),
+    ):
+        mock_builder = MagicMock()
+        mock_builder.build = AsyncMock(return_value=built)
+        mock_builder_factory.return_value = mock_builder
+
+        import time
+
+        await harness._run_pipeline(ctx, run_id="r1", t0=time.perf_counter())
+
+    # Continuation message should be first
+    assert len(captured_messages) >= 2
+    first = captured_messages[0]
+    assert first["role"] == "system"
+    assert "<compaction-summary>" in first["content"]
+    assert "robot navigated to zone B" in first["content"]
+
+
+@pytest.mark.asyncio
+async def test_harness_no_injection_when_not_compacted():
+    """When was_compacted=False, no continuation message is injected."""
+    from castor.harness.core import AgentHarness, HarnessContext
+
+    harness = AgentHarness.__new__(AgentHarness)
+    harness.hooks = []
+    harness.span_tracer = None
+
+    built = _make_built_context(was_compacted=False)
+
+    ctx = HarnessContext(
+        instruction="status check",
+        mission_state={},
+    )
+
+    captured_messages: list = []
+
+    async def fake_tool_loop(ctx, built, **kwargs):
+        captured_messages.extend(built.messages)
+        mock_thought = MagicMock()
+        mock_thought.raw_text = "ok"
+        return mock_thought, [], 1
+
+    with (
+        patch.object(harness, "_get_context_builder") as mock_builder_factory,
+        patch.object(harness, "_tool_loop", new=fake_tool_loop),
+        patch.object(harness, "_log_trajectory", new=AsyncMock()),
+        patch("castor.harness.core.asyncio.ensure_future"),
+    ):
+        mock_builder = MagicMock()
+        mock_builder.build = AsyncMock(return_value=built)
+        mock_builder_factory.return_value = mock_builder
+
+        import time
+
+        await harness._run_pipeline(ctx, run_id="r2", t0=time.perf_counter())
+
+    # No continuation message — only the original user message
+    assert len(captured_messages) == 1
+    assert captured_messages[0]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_harness_suppress_follow_up_when_autonomous():
+    """With mission_state["autonomous"]=True, continuation includes suppress_follow_up."""
+    from castor.harness.core import AgentHarness, HarnessContext
+
+    harness = AgentHarness.__new__(AgentHarness)
+    harness.hooks = []
+    harness.span_tracer = None
+
+    built = _make_built_context(was_compacted=True, compact_summary="completed step 3 of 5")
+
+    ctx = HarnessContext(
+        instruction="continue",
+        mission_state={"autonomous": True},
+    )
+
+    captured_messages: list = []
+
+    async def fake_tool_loop(ctx, built, **kwargs):
+        captured_messages.extend(built.messages)
+        mock_thought = MagicMock()
+        mock_thought.raw_text = "ok"
+        return mock_thought, [], 1
+
+    with (
+        patch.object(harness, "_get_context_builder") as mock_builder_factory,
+        patch.object(harness, "_tool_loop", new=fake_tool_loop),
+        patch.object(harness, "_log_trajectory", new=AsyncMock()),
+        patch("castor.harness.core.asyncio.ensure_future"),
+    ):
+        mock_builder = MagicMock()
+        mock_builder.build = AsyncMock(return_value=built)
+        mock_builder_factory.return_value = mock_builder
+
+        import time
+
+        await harness._run_pipeline(ctx, run_id="r3", t0=time.perf_counter())
+
+    first = captured_messages[0]
+    assert first["role"] == "system"
+    assert "Do not acknowledge" in first["content"]


### PR DESCRIPTION
## Summary

- Adds `compact_summary: str = ""` field to `BuiltContext` so the compaction summary is available to callers
- Updates `_compact_history()` to return a 3-tuple `(messages, was_compacted, summary_text)`
- Both `castor/harness/core.py` and `castor/harness.py` inject a `build_continuation_message()` system message as the first message when `built.was_compacted=True`, preventing cold-start recap turns
- When `mission_state["autonomous"]=True`, adds `suppress_follow_up=True` to silence acknowledgment turns

## Test plan

- [x] `test_built_context_has_compact_summary_field` — BuiltContext carries the new field
- [x] `test_built_context_compact_summary_default_empty` — default is empty string
- [x] `test_compact_history_returns_summary_text` — 3-tuple return with summary text
- [x] `test_compact_history_fallback_returns_empty_summary` — fallback path returns ""
- [x] `test_harness_injects_continuation_on_compaction` — system message injected first
- [x] `test_harness_no_injection_when_not_compacted` — no injection when not compacted
- [x] `test_harness_suppress_follow_up_when_autonomous` — "Do not acknowledge" present in autonomous mode

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)