### PR TITLE
feat(conformance): add rcan_v3 category — 4 structural checks for RCAN 3.x

### DIFF
--- a/castor/compliance.py
+++ b/castor/compliance.py
@@ -104,7 +104,9 @@ def print_report_text(report: ComplianceReport, file: IO[str] = sys.stdout) -> N
     )
     print(file=file)
     for check in report.checks:
-        icon = {"pass": "✅", "warn": "⚠️ ", "fail": "❌"}.get(check.get("status", ""), "❓")
+        icon = {"pass": "✅", "warn": "⚠️ ", "fail": "❌", "skip": "⏭ "}.get(
+            check.get("status", ""), "❓"
+        )
         print(f"  {icon} [{check.get('check_id', '?')}] {check.get('message', '')}", file=file)
         if check.get("detail"):
             print(f"       {check['detail']}", file=file)

--- a/castor/conformance.py
+++ b/castor/conformance.py
@@ -59,7 +59,7 @@ _UUID4_RE = re.compile(
 class ConformanceResult:
     check_id: str  # e.g. "safety.estop_configured"
     category: str  # "safety" | "provider" | "protocol" | "performance" | "hardware"
-    status: str  # "pass" | "warn" | "fail"
+    status: str  # "pass" | "warn" | "fail" | "skip"
     detail: str  # human-readable explanation
     fix: str | None = field(default=None)  # suggested fix
 
@@ -96,6 +96,7 @@ class ConformanceChecker:
             "rcan_v15",
             "rcan_v16",
             "rcan_v21",
+            "rcan_v3",
         ):
             results.extend(self.run_category(category))
         return results
@@ -112,6 +113,7 @@ class ConformanceChecker:
             "rcan_v15": self._check_rcan_v15,
             "rcan_v16": self._check_rcan_v16,
             "rcan_v21": self._check_rcan_v21,
+            "rcan_v3": self._check_rcan_v3,
         }
         runner = runners.get(category)
         if runner is None:
@@ -2174,3 +2176,193 @@ class ConformanceChecker:
                 },
             ],
         }
+
+    # ------------------------------------------------------------------
+    # RCAN 3.x — structural contract for ROBOT.md manifests
+    # ------------------------------------------------------------------
+    #
+    # 3.x is a hard-cut from 2.x: signed-by-default, agent.runtimes[]
+    # replaces the single brain block, RRN is the canonical identity.
+    # Each check returns ``skip`` for non-3.x manifests so 2.x fleets
+    # don't get spurious failures from a category that doesn't apply.
+
+    _V3_RRN_PATTERN = re.compile(r"^RRN-\d{12}$")
+    _V3_ACCEPTED_SIGNING_ALGS = ("pqc-hybrid-v1", "ml-dsa-65")
+
+    def _v3_is_3x(self) -> bool:
+        ver = str(self._cfg.get("rcan_version", "")).strip()
+        try:
+            major = int(ver.split(".")[0])
+        except (ValueError, IndexError):
+            return False
+        return major == 3
+
+    def _v3_skip(self, check_id: str, reason: str) -> ConformanceResult:
+        return ConformanceResult(
+            check_id=check_id,
+            category="rcan_v3",
+            status="skip",
+            detail=reason,
+        )
+
+    def _check_rcan_v3(self) -> list[ConformanceResult]:
+        return [
+            self._v3_rcan_version(),
+            self._v3_signing_alg(),
+            self._v3_agent_runtimes(),
+            self._v3_rrn_format(),
+        ]
+
+    def _v3_rcan_version(self) -> ConformanceResult:
+        cid = "rcan_v3.rcan_version"
+        ver = str(self._cfg.get("rcan_version", "")).strip()
+        if not self._v3_is_3x():
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="skip",
+                detail=f"rcan_version is '{ver}' — v3 checks apply only to 3.x manifests",
+            )
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="pass",
+            detail=f"rcan_version is '{ver}' — runs the v3 structural contract",
+        )
+
+    def _v3_signing_alg(self) -> ConformanceResult:
+        cid = "rcan_v3.signing_alg"
+        if not self._v3_is_3x():
+            return self._v3_skip(cid, "skipped: not a 3.x manifest")
+        network = self._cfg.get("network") or {}
+        alg = network.get("signing_alg")
+        if alg is None:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="warn",
+                detail="network.signing_alg not declared — 3.x recommends explicit declaration",
+                fix="Set network.signing_alg: 'pqc-hybrid-v1' (or 'ml-dsa-65') in your manifest",
+            )
+        if alg in self._V3_ACCEPTED_SIGNING_ALGS:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="pass",
+                detail=f"network.signing_alg is '{alg}' — post-quantum compliant",
+            )
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="fail",
+            detail=(
+                f"network.signing_alg is '{alg}' — 3.x requires a post-quantum option "
+                f"(one of {', '.join(self._V3_ACCEPTED_SIGNING_ALGS)})"
+            ),
+            fix="Set network.signing_alg: 'pqc-hybrid-v1' to retain ed25519 alongside ML-DSA-65",
+        )
+
+    def _v3_agent_runtimes(self) -> ConformanceResult:
+        cid = "rcan_v3.agent_runtimes"
+        if not self._v3_is_3x():
+            return self._v3_skip(cid, "skipped: not a 3.x manifest")
+
+        # Reject the legacy single-brain block — 3.x forbids it.
+        if self._cfg.get("brain") and not self._cfg.get("agent"):
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=(
+                    "manifest has legacy 'brain' block but no 'agent.runtimes[]' — "
+                    "3.x replaces single brain with a list of runtimes"
+                ),
+                fix="Migrate brain → agent.runtimes[] (see `castor migrate` or rcan-spec §3.0)",
+            )
+
+        agent = self._cfg.get("agent")
+        if not isinstance(agent, dict):
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail="missing 'agent' block — 3.x requires agent.runtimes[]",
+                fix="Add agent.runtimes[] declaring at least one runtime with id+models[]",
+            )
+
+        runtimes = agent.get("runtimes")
+        if not isinstance(runtimes, list) or not runtimes:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail="agent.runtimes[] missing or empty — 3.x requires ≥1 runtime entry",
+                fix="Declare at least one runtime with id, harness, and models[]",
+            )
+
+        for i, rt in enumerate(runtimes):
+            if not isinstance(rt, dict):
+                return ConformanceResult(
+                    check_id=cid,
+                    category="rcan_v3",
+                    status="fail",
+                    detail=f"agent.runtimes[{i}] is not a mapping",
+                )
+            if not rt.get("id"):
+                return ConformanceResult(
+                    check_id=cid,
+                    category="rcan_v3",
+                    status="fail",
+                    detail=f"agent.runtimes[{i}] missing 'id' field",
+                    fix="Each runtime must declare a string 'id' (e.g., 'opencastor', 'robot-md')",
+                )
+            models = rt.get("models")
+            if not isinstance(models, list) or not models:
+                return ConformanceResult(
+                    check_id=cid,
+                    category="rcan_v3",
+                    status="fail",
+                    detail=(
+                        f"agent.runtimes[{rt['id']}].models is missing or empty — "
+                        "each runtime must declare ≥1 model"
+                    ),
+                    fix="Add models[] with provider+model+role for each runtime",
+                )
+
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="pass",
+            detail=f"agent.runtimes[] declares {len(runtimes)} runtime(s)",
+        )
+
+    def _v3_rrn_format(self) -> ConformanceResult:
+        cid = "rcan_v3.rrn_format"
+        if not self._v3_is_3x():
+            return self._v3_skip(cid, "skipped: not a 3.x manifest")
+        rrn = (self._cfg.get("metadata") or {}).get("rrn")
+        if not rrn:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail="metadata.rrn missing — 3.x manifests must declare an RRN",
+                fix="Run `robot-md register` to mint an RRN and populate metadata.rrn",
+            )
+        if not self._V3_RRN_PATTERN.match(rrn):
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=(
+                    f"metadata.rrn is '{rrn}' — must match RRN-NNNNNNNNNNNN "
+                    "(uppercase 'RRN-' prefix + 12 digits)"
+                ),
+                fix="Re-mint via `robot-md register` or correct the RRN to canonical shape",
+            )
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="pass",
+            detail=f"metadata.rrn is '{rrn}' — canonical shape",
+        )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -170,7 +170,7 @@ class TestRunAll:
         results = checker_from(cfg).run_all()
         for r in results:
             assert isinstance(r, ConformanceResult)
-            assert r.status in ("pass", "warn", "fail")
+            assert r.status in ("pass", "warn", "fail", "skip")
 
     def test_run_unknown_category_raises(self):
         chk = checker_from(make_valid_config())

--- a/tests/test_conformance_v3.py
+++ b/tests/test_conformance_v3.py
@@ -1,0 +1,233 @@
+"""Tests for RCAN 3.x-specific conformance checks.
+
+Pins the structural contract for RCAN 3.0+ ROBOT.md manifests:
+
+- Version gate: checks return ``skip`` if rcan_version isn't 3.x.
+- Signing algorithm: must declare a post-quantum option
+  (``pqc-hybrid-v1`` or ``ml-dsa-65``).
+- agent.runtimes[]: 3.x replaces the single ``brain`` block with a list
+  of runtimes, each declaring ``id``, ``harness``, and ``models[]``.
+- RRN format: ``metadata.rrn`` must match ``RRN-\\d{12}``.
+
+Bob's manifest (RRN-000000000002, rcan_version=3.2) is the canonical
+shape these tests pin against.
+"""
+
+from __future__ import annotations
+
+from castor.conformance import ConformanceChecker
+
+
+def _bob_like_3x_config() -> dict:
+    """Minimal RCAN 3.x config that should pass all _v3_* checks."""
+    return {
+        "rcan_version": "3.2",
+        "metadata": {
+            "robot_name": "bob",
+            "rrn": "RRN-000000000099",
+        },
+        "network": {
+            "signing_alg": "pqc-hybrid-v1",
+        },
+        "agent": {
+            "runtimes": [
+                {
+                    "id": "opencastor",
+                    "harness": "castor-default",
+                    "default": True,
+                    "models": [
+                        {
+                            "provider": "anthropic",
+                            "model": "claude-sonnet-4-6",
+                            "role": "primary",
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+# ---- _v3_rcan_version (gate) ---------------------------------------------
+
+
+def test_v3_rcan_version_gate_passes_for_3x():
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    results = [r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.rcan_version"]
+    assert len(results) == 1
+    assert results[0].status == "pass"
+
+
+def test_v3_rcan_version_gate_skips_for_2x():
+    """2.x manifests skip 3.x-only checks. Skip ≠ fail (don't bother
+    a 2.x fleet manifest with 3.x-specific structural assertions)."""
+    cfg = _bob_like_3x_config()
+    cfg["rcan_version"] = "2.2"
+    checker = ConformanceChecker(cfg)
+    results = checker.run_category("rcan_v3")
+    # All v3 checks should skip — none fail
+    assert results, "rcan_v3 category must always emit at least the version gate"
+    assert all(r.status == "skip" for r in results), (
+        f"non-3.x manifest should skip all v3 checks; got: "
+        f"{[(r.check_id, r.status) for r in results]}"
+    )
+
+
+def test_v3_rcan_version_gate_passes_for_3_3():
+    cfg = _bob_like_3x_config()
+    cfg["rcan_version"] = "3.3"
+    checker = ConformanceChecker(cfg)
+    results = [r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.rcan_version"]
+    assert results[0].status == "pass"
+
+
+# ---- _v3_signing_alg ------------------------------------------------------
+
+
+def test_v3_signing_alg_pqc_hybrid_passes():
+    cfg = _bob_like_3x_config()
+    cfg["network"]["signing_alg"] = "pqc-hybrid-v1"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.signing_alg")
+    assert r.status == "pass"
+
+
+def test_v3_signing_alg_ml_dsa_65_passes():
+    """ml-dsa-65 alone (without ed25519 hybrid) is also acceptable in 3.x."""
+    cfg = _bob_like_3x_config()
+    cfg["network"]["signing_alg"] = "ml-dsa-65"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.signing_alg")
+    assert r.status == "pass"
+
+
+def test_v3_signing_alg_ed25519_only_fails():
+    """ed25519 alone is deprecated in 3.x — must opt into PQ."""
+    cfg = _bob_like_3x_config()
+    cfg["network"]["signing_alg"] = "ed25519"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.signing_alg")
+    assert r.status == "fail"
+    assert r.fix is not None and "pqc-hybrid-v1" in r.fix
+
+
+def test_v3_signing_alg_missing_warns():
+    """No declaration = warn (operator should declare explicitly)."""
+    cfg = _bob_like_3x_config()
+    cfg["network"].pop("signing_alg", None)
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.signing_alg")
+    assert r.status == "warn"
+
+
+# ---- _v3_agent_runtimes ---------------------------------------------------
+
+
+def test_v3_agent_runtimes_valid_passes():
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.agent_runtimes")
+    assert r.status == "pass"
+
+
+def test_v3_agent_runtimes_missing_fails():
+    """3.x mandates agent.runtimes[] (replaces single brain block)."""
+    cfg = _bob_like_3x_config()
+    cfg.pop("agent", None)
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.agent_runtimes")
+    assert r.status == "fail"
+
+
+def test_v3_agent_runtimes_empty_list_fails():
+    cfg = _bob_like_3x_config()
+    cfg["agent"]["runtimes"] = []
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.agent_runtimes")
+    assert r.status == "fail"
+
+
+def test_v3_agent_runtimes_legacy_brain_block_fails():
+    """3.x forbids the single-brain shape; must migrate to agent.runtimes[]."""
+    cfg = _bob_like_3x_config()
+    cfg.pop("agent", None)
+    cfg["brain"] = {"planning_provider": "anthropic", "planning_model": "claude-3"}
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.agent_runtimes")
+    assert r.status == "fail"
+    assert "brain" in (r.detail or "").lower() or "runtimes" in (r.detail or "").lower()
+
+
+def test_v3_agent_runtimes_runtime_missing_id_fails():
+    cfg = _bob_like_3x_config()
+    del cfg["agent"]["runtimes"][0]["id"]
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.agent_runtimes")
+    assert r.status == "fail"
+
+
+def test_v3_agent_runtimes_runtime_no_models_fails():
+    cfg = _bob_like_3x_config()
+    cfg["agent"]["runtimes"][0]["models"] = []
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.agent_runtimes")
+    assert r.status == "fail"
+
+
+# ---- _v3_rrn_format -------------------------------------------------------
+
+
+def test_v3_rrn_format_valid_passes():
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.rrn_format")
+    assert r.status == "pass"
+
+
+def test_v3_rrn_format_missing_fails():
+    cfg = _bob_like_3x_config()
+    cfg["metadata"].pop("rrn", None)
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.rrn_format")
+    assert r.status == "fail"
+
+
+def test_v3_rrn_format_wrong_shape_fails():
+    """RRN must be RRN- + 12 digits. Anything else fails."""
+    cfg = _bob_like_3x_config()
+    cfg["metadata"]["rrn"] = "RRN-12345"  # too short
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.rrn_format")
+    assert r.status == "fail"
+
+
+def test_v3_rrn_format_lowercase_fails():
+    cfg = _bob_like_3x_config()
+    cfg["metadata"]["rrn"] = "rrn-000000000099"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.rrn_format")
+    assert r.status == "fail"
+
+
+# ---- category integration -------------------------------------------------
+
+
+def test_run_all_includes_rcan_v3_for_3x_manifest():
+    """run_all() must execute the v3 category for 3.x manifests."""
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    all_results = checker.run_all()
+    v3_results = [r for r in all_results if r.category == "rcan_v3"]
+    assert len(v3_results) >= 4, f"expected ≥4 v3 checks; got {len(v3_results)}"
+
+
+def test_run_all_includes_rcan_v3_for_2x_manifest_but_skipped():
+    """run_all() always runs the v3 category — 2.x manifests skip the contents."""
+    cfg = _bob_like_3x_config()
+    cfg["rcan_version"] = "2.2"
+    checker = ConformanceChecker(cfg)
+    all_results = checker.run_all()
+    v3_results = [r for r in all_results if r.category == "rcan_v3"]
+    assert v3_results, "rcan_v3 category must run unconditionally"
+    assert all(r.status == "skip" for r in v3_results)


### PR DESCRIPTION
## Why

`castor compliance --config ROBOT.md` was running on bob's RCAN 3.2
manifest after PR #873, but the conformance checks fell back to
generic semver-only gates. There was no 3.x-specific structural
contract being asserted. This PR pins what \"a valid 3.x manifest\"
looks like, mirroring the existing `rcan_v12` / `_v15` / `_v16` /
`_v21` check families.

## What

New `rcan_v3` category with 4 checks:

1. **`rcan_v3.rcan_version`** — gate. `pass` when major=3; `skip`
   otherwise. Skip ≠ fail: 2.x manifests don't get spurious failures
   from a category that doesn't apply to them.

2. **`rcan_v3.signing_alg`** — `network.signing_alg` must be one of:
   - `pqc-hybrid-v1` (recommended; ML-DSA-65 + Ed25519)
   - `ml-dsa-65`

   `ed25519` alone fails (deprecated in 3.x). Missing declaration
   warns (operator should declare explicitly).

3. **`rcan_v3.agent_runtimes`** — 3.x replaces the single `brain`
   block with `agent.runtimes[]`. Asserts:
   - `agent` dict present
   - `runtimes` is a non-empty list
   - each runtime has `id` and at least one model in `models[]`

   Legacy `brain` block without `agent.runtimes[]` = explicit fail.

4. **`rcan_v3.rrn_format`** — `metadata.rrn` must match
   `RRN-NNNNNNNNNNNN` (uppercase prefix + 12 digits).

## ConformanceResult.status

Adds `\"skip\"` alongside `pass`/`warn`/`fail`:
- `ComplianceReport` tally: skip is not-a-fail (compliant unaffected)
  and not-a-pass (no contribution to passed count).
- `print_report_text` icon map: ⏭ for skip.
- Older check_ids that produce only pass/warn/fail are unaffected.

## Verification

- 19 new tests in `tests/test_conformance_v3.py`.
- 168/168 conformance + compliance tests pass (one existing test
  updated: `test_all_results_are_conformance_result` now accepts
  `\"skip\"` as a valid status).
- End-to-end on bob's actual ROBOT.md (RRN-000000000002,
  rcan_version 3.2, signing_alg pqc-hybrid-v1, 2 runtimes):
  ```
  ✅ [rcan_v3.rcan_version] rcan_version is '3.2' — runs the v3 structural contract
  ✅ [rcan_v3.signing_alg] network.signing_alg is 'pqc-hybrid-v1' — post-quantum compliant
  ✅ [rcan_v3.agent_runtimes] agent.runtimes[] declares 2 runtime(s)
  ✅ [rcan_v3.rrn_format] metadata.rrn is 'RRN-000000000002' — canonical shape
  ```

Builds on PR #873 (just merged), which made `_load_config` accept
ROBOT.md frontmatter. Without it, no 3.x manifest reached the
conformance checker at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)