### PR TITLE
feat(conformance): rcan_v3 slice 2 — estop budget + capability hygiene + record_url drift

### DIFF
--- a/castor/conformance.py
+++ b/castor/conformance.py
@@ -2211,6 +2211,9 @@ class ConformanceChecker:
             self._v3_signing_alg(),
             self._v3_agent_runtimes(),
             self._v3_rrn_format(),
+            self._v3_estop_response_ms(),
+            self._v3_capability_namespacing(),
+            self._v3_record_url(),
         ]
 
     def _v3_rcan_version(self) -> ConformanceResult:
@@ -2365,4 +2368,156 @@ class ConformanceChecker:
             category="rcan_v3",
             status="pass",
             detail=f"metadata.rrn is '{rrn}' — canonical shape",
+        )
+
+    # ----- slice 2: reactive-safety + capability hygiene + record-URL drift
+
+    _V3_ESTOP_RESPONSE_CEILING_MS = 100  # EU AI Act Art. 9 collaborative-manipulator budget
+    _V3_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$")
+    _V3_CANONICAL_RRF_HOST = "robotregistryfoundation.org"
+    _V3_LEGACY_REGISTRY_HOSTS = ("rcan.dev",)
+
+    def _v3_estop_response_ms(self) -> ConformanceResult:
+        cid = "rcan_v3.estop_response_ms"
+        if not self._v3_is_3x():
+            return self._v3_skip(cid, "skipped: not a 3.x manifest")
+        estop = (self._cfg.get("safety") or {}).get("estop") or {}
+        if not estop.get("software"):
+            return self._v3_skip(cid, "skipped: no software estop declared")
+        rms = estop.get("response_ms")
+        if rms is None:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=(
+                    "safety.estop.software=true but response_ms not declared — "
+                    "Art. 9 reactive-safety budget undefined"
+                ),
+                fix=(
+                    "Declare safety.estop.response_ms (≤ "
+                    f"{self._V3_ESTOP_RESPONSE_CEILING_MS}ms for collaborative manipulators)"
+                ),
+            )
+        try:
+            rms_int = int(rms)
+        except (TypeError, ValueError):
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=f"safety.estop.response_ms is '{rms}' — must be an integer (milliseconds)",
+            )
+        if rms_int > self._V3_ESTOP_RESPONSE_CEILING_MS:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=(
+                    f"safety.estop.response_ms is {rms_int}ms — exceeds "
+                    f"{self._V3_ESTOP_RESPONSE_CEILING_MS}ms ceiling for collaborative "
+                    "manipulators (Art. 9 risk-management)"
+                ),
+                fix=(
+                    "Tune driver/firmware so estop dispatch lands within "
+                    f"{self._V3_ESTOP_RESPONSE_CEILING_MS}ms, then update response_ms"
+                ),
+            )
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="pass",
+            detail=f"safety.estop.response_ms is {rms_int}ms — within Art. 9 budget",
+        )
+
+    def _v3_capability_namespacing(self) -> ConformanceResult:
+        cid = "rcan_v3.capability_namespacing"
+        if not self._v3_is_3x():
+            return self._v3_skip(cid, "skipped: not a 3.x manifest")
+        caps = self._cfg.get("capabilities") or []
+        if not isinstance(caps, list):
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail="capabilities must be a list",
+            )
+        bad = [c for c in caps if not (isinstance(c, str) and self._V3_CAPABILITY_PATTERN.match(c))]
+        if bad:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=(
+                    f"{len(bad)} capability name(s) violate dotted verb.noun shape: "
+                    f"{', '.join(repr(c) for c in bad[:5])}" + ("..." if len(bad) > 5 else "")
+                ),
+                fix="Rename to `verb.noun` (e.g., `pick` → `manipulate.pick`, `wave` → `manipulate.wave`)",
+            )
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="pass",
+            detail=f"all {len(caps)} capability name(s) use dotted verb.noun shape",
+        )
+
+    def _v3_record_url(self) -> ConformanceResult:
+        cid = "rcan_v3.record_url"
+        if not self._v3_is_3x():
+            return self._v3_skip(cid, "skipped: not a 3.x manifest")
+        meta = self._cfg.get("metadata") or {}
+        rrn = meta.get("rrn")
+        if not rrn:
+            return self._v3_skip(
+                cid, "skipped: no rrn declared (record_url has nothing to canonicalize against)"
+            )
+        record_url = meta.get("record_url")
+        if not record_url:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="warn",
+                detail=f"metadata.record_url not declared — recommended for {rrn}",
+                fix=(
+                    f"Set metadata.record_url: 'https://{self._V3_CANONICAL_RRF_HOST}"
+                    f"/v2/robots/{rrn}'"
+                ),
+            )
+        for legacy in self._V3_LEGACY_REGISTRY_HOSTS:
+            if legacy in record_url:
+                return ConformanceResult(
+                    check_id=cid,
+                    category="rcan_v3",
+                    status="fail",
+                    detail=(
+                        f"metadata.record_url points at legacy {legacy!r} — "
+                        f"3.x ecosystem is on {self._V3_CANONICAL_RRF_HOST} (peer-runtimes "
+                        "cascade 2026-04-24)"
+                    ),
+                    fix=(
+                        f"Update metadata.record_url to 'https://{self._V3_CANONICAL_RRF_HOST}"
+                        f"/v2/robots/{rrn}'"
+                    ),
+                )
+        # Confirm rrn appears in the URL — guards against copy-paste of
+        # someone else's record_url.
+        if rrn not in record_url:
+            return ConformanceResult(
+                check_id=cid,
+                category="rcan_v3",
+                status="fail",
+                detail=(
+                    f"metadata.record_url '{record_url}' does not reference "
+                    f"metadata.rrn '{rrn}' — likely a stale copy-paste"
+                ),
+                fix=(
+                    f"Set metadata.record_url to 'https://{self._V3_CANONICAL_RRF_HOST}"
+                    f"/v2/robots/{rrn}'"
+                ),
+            )
+        return ConformanceResult(
+            check_id=cid,
+            category="rcan_v3",
+            status="pass",
+            detail=f"metadata.record_url references {rrn} on {self._V3_CANONICAL_RRF_HOST}",
         )

--- a/tests/test_conformance_v3_slice2.py
+++ b/tests/test_conformance_v3_slice2.py
@@ -1,0 +1,241 @@
+"""Second slice of RCAN 3.x conformance checks.
+
+Builds on tests/test_conformance_v3.py (slice 1: rcan_version, signing_alg,
+agent_runtimes, rrn_format). This slice adds:
+
+- estop_response_ms — Art. 9 reactive-safety budget. When
+  safety.estop.software is declared, response_ms must be declared AND
+  bounded (≤ 100ms is the EU AI Act risk-management ceiling for
+  human-collaborating manipulators).
+- capability_namespacing — 3.x mandates dotted `verb.noun` shape for
+  capabilities[] (e.g., `manipulate.pick`, `perceive.rgb`). Catches
+  legacy bare names like `pick` or `wave`.
+- record_url — when metadata.rrn is declared, metadata.record_url must
+  reference the canonical RRF v2 path
+  (https://robotregistryfoundation.org/v2/robots/<rrn>). Catches stale
+  rcan.dev refs that survived the cascade migration.
+"""
+
+from __future__ import annotations
+
+from castor.conformance import ConformanceChecker
+
+
+def _bob_like_3x_config() -> dict:
+    """Minimal RCAN 3.x config that should pass all _v3_* checks."""
+    return {
+        "rcan_version": "3.2",
+        "metadata": {
+            "robot_name": "bob",
+            "rrn": "RRN-000000000099",
+            "record_url": "https://robotregistryfoundation.org/v2/robots/RRN-000000000099",
+        },
+        "network": {"signing_alg": "pqc-hybrid-v1"},
+        "agent": {
+            "runtimes": [
+                {
+                    "id": "opencastor",
+                    "harness": "castor-default",
+                    "models": [
+                        {"provider": "anthropic", "model": "claude-sonnet-4-6", "role": "primary"}
+                    ],
+                }
+            ],
+        },
+        "safety": {"estop": {"software": True, "response_ms": 50}},
+        "capabilities": ["manipulate.pick", "manipulate.place", "perceive.rgb"],
+    }
+
+
+# ---- _v3_estop_response_ms ------------------------------------------------
+
+
+def test_v3_estop_response_ms_declared_passes():
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.estop_response_ms"
+    )
+    assert r.status == "pass"
+
+
+def test_v3_estop_response_ms_skips_when_no_software_estop():
+    """If software estop isn't declared, the budget check is N/A."""
+    cfg = _bob_like_3x_config()
+    cfg["safety"]["estop"]["software"] = False
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.estop_response_ms"
+    )
+    assert r.status == "skip"
+
+
+def test_v3_estop_response_ms_missing_when_software_declared_fails():
+    """software: true without a response_ms = silent reactive-safety hole."""
+    cfg = _bob_like_3x_config()
+    cfg["safety"]["estop"] = {"software": True}
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.estop_response_ms"
+    )
+    assert r.status == "fail"
+    assert "response_ms" in (r.detail or "")
+
+
+def test_v3_estop_response_ms_over_budget_fails():
+    """200ms > 100ms ceiling for collaborative manipulators."""
+    cfg = _bob_like_3x_config()
+    cfg["safety"]["estop"]["response_ms"] = 200
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.estop_response_ms"
+    )
+    assert r.status == "fail"
+    assert "100" in (r.detail or "")
+
+
+def test_v3_estop_response_ms_at_ceiling_passes():
+    """Exactly 100ms is acceptable — strict ≤ ceiling."""
+    cfg = _bob_like_3x_config()
+    cfg["safety"]["estop"]["response_ms"] = 100
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.estop_response_ms"
+    )
+    assert r.status == "pass"
+
+
+def test_v3_estop_response_ms_skips_for_2x():
+    cfg = _bob_like_3x_config()
+    cfg["rcan_version"] = "2.2"
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.estop_response_ms"
+    )
+    assert r.status == "skip"
+
+
+# ---- _v3_capability_namespacing -------------------------------------------
+
+
+def test_v3_capability_namespacing_dotted_passes():
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.capability_namespacing"
+    )
+    assert r.status == "pass"
+
+
+def test_v3_capability_namespacing_legacy_bare_fails():
+    """Bare names like `pick`, `wave` are pre-3.x — must be `manipulate.pick`."""
+    cfg = _bob_like_3x_config()
+    cfg["capabilities"] = ["pick", "manipulate.place"]
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.capability_namespacing"
+    )
+    assert r.status == "fail"
+    assert "pick" in (r.detail or "")
+
+
+def test_v3_capability_namespacing_empty_list_passes():
+    """No capabilities declared = no naming violations possible."""
+    cfg = _bob_like_3x_config()
+    cfg["capabilities"] = []
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.capability_namespacing"
+    )
+    assert r.status == "pass"
+
+
+def test_v3_capability_namespacing_double_dot_passes():
+    """Multi-segment names like `manipulate.pick.precise` are valid."""
+    cfg = _bob_like_3x_config()
+    cfg["capabilities"] = ["manipulate.pick.precise", "perceive.rgb.stream"]
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.capability_namespacing"
+    )
+    assert r.status == "pass"
+
+
+def test_v3_capability_namespacing_skips_for_2x():
+    cfg = _bob_like_3x_config()
+    cfg["rcan_version"] = "2.2"
+    checker = ConformanceChecker(cfg)
+    r = next(
+        r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.capability_namespacing"
+    )
+    assert r.status == "skip"
+
+
+# ---- _v3_record_url -------------------------------------------------------
+
+
+def test_v3_record_url_canonical_passes():
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.record_url")
+    assert r.status == "pass"
+
+
+def test_v3_record_url_missing_when_rrn_present_warns():
+    """Having an rrn but no record_url is a documentation gap, not a fail."""
+    cfg = _bob_like_3x_config()
+    cfg["metadata"].pop("record_url", None)
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.record_url")
+    assert r.status == "warn"
+
+
+def test_v3_record_url_stale_rcan_dev_fails():
+    """rcan.dev was the old registry; cascade moved everything to RRF v2.
+    A stale rcan.dev URL is an explicit drift signal, not a warning."""
+    cfg = _bob_like_3x_config()
+    cfg["metadata"]["record_url"] = "https://rcan.dev/api/v1/robots/RRN-000000000099"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.record_url")
+    assert r.status == "fail"
+    assert "rcan.dev" in (r.detail or "") or "robotregistryfoundation" in (r.detail or "")
+
+
+def test_v3_record_url_wrong_rrn_fails():
+    """record_url must reference the same RRN as metadata.rrn."""
+    cfg = _bob_like_3x_config()
+    cfg["metadata"]["record_url"] = "https://robotregistryfoundation.org/v2/robots/RRN-999999999999"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.record_url")
+    assert r.status == "fail"
+
+
+def test_v3_record_url_skips_when_rrn_missing():
+    """Without an rrn, there's no canonical URL to validate against."""
+    cfg = _bob_like_3x_config()
+    cfg["metadata"].pop("rrn", None)
+    cfg["metadata"].pop("record_url", None)
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.record_url")
+    assert r.status == "skip"
+
+
+def test_v3_record_url_skips_for_2x():
+    cfg = _bob_like_3x_config()
+    cfg["rcan_version"] = "2.2"
+    checker = ConformanceChecker(cfg)
+    r = next(r for r in checker.run_category("rcan_v3") if r.check_id == "rcan_v3.record_url")
+    assert r.status == "skip"
+
+
+# ---- category integration -------------------------------------------------
+
+
+def test_run_all_includes_seven_v3_checks():
+    """Slice 1 (4) + slice 2 (3) = 7 v3 checks total."""
+    cfg = _bob_like_3x_config()
+    checker = ConformanceChecker(cfg)
+    v3_results = [r for r in checker.run_all() if r.category == "rcan_v3"]
+    assert len(v3_results) == 7, (
+        f"expected 7 v3 checks; got {len(v3_results)}: {[r.check_id for r in v3_results]}"
+    )


### PR DESCRIPTION
## Summary

Builds on PR #874 (slice 1: `rcan_version`, `signing_alg`, `agent_runtimes`, `rrn_format`) with three more RCAN 3.x structural checks. Each runs unconditionally in the `rcan_v3` category and skips on non-3.x manifests.

### `rcan_v3.estop_response_ms`

Art. 9 reactive-safety budget. When `safety.estop.software` is declared, `response_ms` must be declared AND ≤ 100ms (EU AI Act risk-management ceiling for collaborative manipulators). Catches:
- software estop with no `response_ms` → fail (silent reactive-safety hole)
- `response_ms` over budget → fail (declared latency too lax for collab use)

Skips when software estop isn't declared (budget check is N/A).

### `rcan_v3.capability_namespacing`

3.x mandates dotted `verb.noun` shape for `capabilities[]` (e.g., `manipulate.pick`, `perceive.rgb`). Pattern: `^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$`. Multi-segment names like `manipulate.pick.precise` accepted. Catches legacy bare names (`pick`, `wave`) that survived 2.x→3.x migration. Empty capabilities list passes (no violations possible).

### `rcan_v3.record_url`

When `metadata.rrn` is declared, `metadata.record_url` must reference the canonical RRF v2 path (`https://robotregistryfoundation.org/v2/robots/<rrn>`). Catches:
- stale `rcan.dev` refs (legacy host pre-cascade) → fail
- `record_url` referencing a different RRN (copy-paste bug) → fail
- `rrn` declared but no `record_url` → warn (documentation gap, not blocker)

Skips when `rrn` isn't declared (nothing to canonicalize against).

## Verification

End-to-end on bob's ROBOT.md (`RRN-000000000002`, `rcan_version=3.2`):

```
✅ [rcan_v3.estop_response_ms] safety.estop.response_ms is 50ms — within Art. 9 budget
✅ [rcan_v3.capability_namespacing] all 5 capability name(s) use dotted verb.noun shape
✅ [rcan_v3.record_url] metadata.record_url references RRN-000000000002 on robotregistryfoundation.org
```

All 7 v3 checks ✅ for bob (4 slice 1 + 3 slice 2).

## Test plan

- [x] 18 new tests in `tests/test_conformance_v3_slice2.py`
- [x] estop_response_ms: 6 tests (declared/missing/over/at-ceiling/no-software/non-3x)
- [x] capability_namespacing: 5 tests (dotted/legacy/empty/multi-segment/non-3x)
- [x] record_url: 6 tests (canonical/missing/stale-rcan.dev/wrong-rrn/no-rrn/non-3x)
- [x] integration: slice-1+slice-2 = 7 v3 checks for 3.x manifests
- [x] 186/186 conformance + compliance tests green
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)