### PR TITLE
fix(api,brain): surface real error + 503 on brain failure (#867 Bug A)

### DIFF
--- a/castor/api.py
+++ b/castor/api.py
@@ -2904,6 +2904,14 @@ async def arm_pick_place(req: _PickPlaceRequest):
         _img_bytes = _b64.b64decode(b64)
         thought = await asyncio.to_thread(state.brain.think, _img_bytes, prompt, "terminal")
         log.append({"phase": phase, "brain_response": thought.raw_text[:200]})
+        # Brain providers signal failure via Thought(raw_text="Error [...]...", action=None)
+        # rather than raising. Surface that as 503 so callers don't see a "successful"
+        # 200 response with an empty-phase log (#867).
+        if thought.action is None and thought.raw_text.startswith("Error"):
+            raise HTTPException(
+                status_code=503,
+                detail=f"Brain unavailable during {phase}: {thought.raw_text[:200]}",
+            )
         return thought.action
 
     def _exec(actions) -> None:

--- a/castor/claude_proxy.py
+++ b/castor/claude_proxy.py
@@ -152,18 +152,32 @@ class ClaudeOAuthClient:
             )
 
             if result.returncode != 0:
-                logger.error("Claude CLI error: %s", result.stderr[:200])
-                return {"content": [{"type": "text", "text": f"Error: {result.stderr[:200]}"}]}
+                # Claude CLI often writes auth/runtime errors to stdout, not stderr;
+                # fall back so the operator sees *why* the CLI failed (#867).
+                err_msg = (
+                    (result.stderr or "").strip()
+                    or (result.stdout or "").strip()
+                    or f"<no output, exit code {result.returncode}>"
+                )
+                logger.error("Claude CLI error (exit %d): %s", result.returncode, err_msg[:500])
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Error [exit {result.returncode}]: {err_msg[:200]}",
+                        }
+                    ]
+                }
 
             text = result.stdout.strip()
             return {"content": [{"type": "text", "text": text}]}
 
         except subprocess.TimeoutExpired:
             logger.error("Claude CLI timed out")
-            return {"content": [{"type": "text", "text": "Error: CLI timeout"}]}
+            return {"content": [{"type": "text", "text": "Error [TimeoutExpired]: CLI timeout"}]}
         except Exception as e:
-            logger.error("Claude CLI failed: %s", e)
-            return {"content": [{"type": "text", "text": f"Error: {e}"}]}
+            logger.error("Claude CLI failed [%s]: %s", type(e).__name__, e)
+            return {"content": [{"type": "text", "text": f"Error [{type(e).__name__}]: {e!r}"}]}
         finally:
             # Clean up temp image file
             if _image_path:

--- a/castor/providers/anthropic_provider.py
+++ b/castor/providers/anthropic_provider.py
@@ -208,8 +208,8 @@ class AnthropicProvider(BaseProvider):
             action = self._clean_json(text)
             return Thought(text, action)
         except Exception as e:
-            logger.error(f"Anthropic error: {e}")
-            return Thought(f"Error: {e}", None)
+            logger.error("Anthropic error [%s]: %r", type(e).__name__, e)
+            return Thought(f"Error [{type(e).__name__}]: {e!r}", None)
 
     def get_usage_stats(self) -> dict:
         """Return session-level token usage and cache stats."""
@@ -288,8 +288,8 @@ class AnthropicProvider(BaseProvider):
                 pass
             return Thought(text, action)
         except Exception as e:
-            logger.error(f"CLI error: {e}")
-            return Thought(f"Error: {e}", None)
+            logger.error("CLI error [%s]: %r", type(e).__name__, e)
+            return Thought(f"Error [{type(e).__name__}]: {e!r}", None)
 
     def think_stream(
         self,

--- a/tests/test_brain_error_surfacing.py
+++ b/tests/test_brain_error_surfacing.py
@@ -1,0 +1,210 @@
+"""Tests for #867 Bug A — brain error surfacing.
+
+Covers four regression paths surfaced by Bob's first live pick_place run:
+
+1. claude_proxy.ClaudeOAuthClient should not return raw_text="Error: " when CLI
+   exits nonzero with empty stderr — stdout / exit code must surface so the
+   operator can tell *why* (expired token, missing binary, etc.).
+
+2. claude_proxy.ClaudeOAuthClient should include the exception class name when
+   subprocess raises an exception whose ``str(e)`` is empty.
+
+3. AnthropicProvider.think error path should include the exception class name.
+
+4. /api/arm/pick_place must return HTTP 503 when the brain fails to plan
+   (raw_text starts with "Error"), not HTTP 200 with an empty-phase log.
+"""
+
+from __future__ import annotations
+
+import collections
+import time
+from unittest.mock import MagicMock, patch
+
+
+# ── 1 + 2. claude_proxy.ClaudeOAuthClient ─────────────────────────────────────
+
+
+class TestClaudeOAuthClientErrorSurfacing:
+    def test_nonzero_returncode_with_empty_stderr_surfaces_stdout(self):
+        """If `claude` exits nonzero with empty stderr, fall back to stdout."""
+        from castor.claude_proxy import ClaudeOAuthClient
+
+        client = ClaudeOAuthClient(oauth_token="sk-ant-oat01-test")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 1
+        fake_result.stderr = ""
+        fake_result.stdout = "Error: Invalid API key · Please run /login"
+
+        with patch("castor.claude_proxy.subprocess.run", return_value=fake_result):
+            resp = client.create_message(
+                model="claude-sonnet-4-6",
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        text = resp["content"][0]["text"]
+        assert text != "Error: ", "regression: empty error swallow returned"
+        assert "Invalid API key" in text or "exit code 1" in text or "/login" in text
+
+    def test_nonzero_returncode_includes_exit_code_when_both_streams_empty(self):
+        """When stderr AND stdout are empty, exit code itself must surface."""
+        from castor.claude_proxy import ClaudeOAuthClient
+
+        client = ClaudeOAuthClient(oauth_token="sk-ant-oat01-test")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 127  # command not found
+        fake_result.stderr = ""
+        fake_result.stdout = ""
+
+        with patch("castor.claude_proxy.subprocess.run", return_value=fake_result):
+            resp = client.create_message(
+                model="claude-sonnet-4-6",
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        text = resp["content"][0]["text"]
+        assert text != "Error: "
+        assert "127" in text  # the exit code itself
+
+    def test_subprocess_exception_with_empty_str_includes_type_name(self):
+        """If subprocess raises with empty str(e), the type name must surface."""
+        from castor.claude_proxy import ClaudeOAuthClient
+
+        class EmptyError(RuntimeError):
+            def __str__(self) -> str:
+                return ""
+
+        client = ClaudeOAuthClient(oauth_token="sk-ant-oat01-test")
+
+        with patch("castor.claude_proxy.subprocess.run", side_effect=EmptyError()):
+            resp = client.create_message(
+                model="claude-sonnet-4-6",
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        text = resp["content"][0]["text"]
+        assert "EmptyError" in text, f"type name missing: {text!r}"
+
+
+# ── 3. AnthropicProvider error path ───────────────────────────────────────────
+
+
+class TestAnthropicProviderErrorPath:
+    def test_think_via_cli_includes_exception_type_in_raw_text(self):
+        """When _think_via_cli's underlying call raises, raw_text should name the type."""
+        from castor.providers.anthropic_provider import AnthropicProvider
+
+        config = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "api_key": "sk-ant-oat01-fake",
+        }
+
+        with patch.object(
+            AnthropicProvider, "_read_stored_token", return_value="sk-ant-oat01-fake"
+        ):
+            with patch("castor.claude_proxy.ClaudeOAuthClient") as mock_client_cls:
+                mock_client = MagicMock()
+
+                class WeirdAuth(Exception):
+                    def __str__(self) -> str:
+                        return ""
+
+                mock_client.create_message.side_effect = WeirdAuth()
+                mock_client_cls.return_value = mock_client
+
+                provider = AnthropicProvider(config)
+
+        # Force CLI path
+        provider._use_cli = True
+        provider._cli_client = mock_client
+        provider._cached_system_blocks = "sys"
+
+        thought = provider._think_via_cli("look at this", b"", "terminal")
+
+        assert thought.raw_text.startswith("Error"), thought.raw_text
+        assert "WeirdAuth" in thought.raw_text, f"type missing: {thought.raw_text!r}"
+
+
+# ── 4. /api/arm/pick_place 503 when brain fails ───────────────────────────────
+
+
+def _make_client_and_reset(monkeypatch):
+    """Same helper pattern as tests/test_depth.py."""
+    monkeypatch.delenv("OPENCASTOR_API_TOKEN", raising=False)
+    monkeypatch.delenv("OPENCASTOR_JWT_SECRET", raising=False)
+
+    import castor.api as api_mod
+
+    api_mod.state.config = None
+    api_mod.state.brain = None
+    api_mod.state.driver = None
+    api_mod.state.channels = {}
+    api_mod.state.last_thought = None
+    api_mod.state.boot_time = time.time()
+    api_mod.state.fs = None
+    api_mod.state.ruri = None
+    api_mod.state.offline_fallback = None
+    api_mod.state.provider_fallback = None
+    api_mod.state.thought_history = collections.deque(maxlen=50)
+    api_mod.API_TOKEN = None
+
+    from starlette.testclient import TestClient
+
+    from castor.api import app
+
+    app.router.on_startup.clear()
+    app.router.on_shutdown.clear()
+
+    import contextlib as _contextlib
+
+    @_contextlib.asynccontextmanager
+    async def _noop_lifespan(app):
+        yield
+
+    app.router.lifespan_context = _noop_lifespan
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestPickPlaceBrainFailure:
+    def test_pick_place_returns_503_when_brain_returns_error_thought(self, monkeypatch):
+        """When state.brain.think() returns Thought(raw_text='Error ...', action=None),
+        /api/arm/pick_place must return 503, not 200 with empty-phase log.
+        """
+        client = _make_client_and_reset(monkeypatch)
+
+        from castor.providers.base import Thought
+        import castor.api as api_mod
+
+        # Driver with arm capability — clears the existing 503 at line 2861
+        mock_driver = MagicMock()
+        mock_driver.set_joint_positions = MagicMock()
+        api_mod.state.driver = mock_driver
+
+        # Brain that always errors
+        mock_brain = MagicMock()
+        mock_brain.think.return_value = Thought(
+            raw_text="Error [AuthenticationError]: token expired",
+            action=None,
+        )
+        api_mod.state.brain = mock_brain
+
+        # Provide a dummy frame so _vision_plan can advance to the brain call
+        with patch("castor.api._capture_live_frame", return_value=b"\xff\xd8" + b"\x00" * 1024):
+            resp = client.post(
+                "/api/arm/pick_place",
+                json={"target": "red lego", "destination": "bowl", "max_vision_steps": 1},
+            )
+
+        assert resp.status_code == 503, (
+            f"expected 503 (brain-failed), got {resp.status_code}: {resp.text}"
+        )
+        body = resp.json()
+        # OpenCastor uses {"error": "...", "code": "HTTP_NNN"} per CLAUDE.md
+        msg = body.get("error", "") or body.get("detail", "")
+        assert "Error" in msg or "rain" in msg, body  # "Error" or "Brain"/"brain"


### PR DESCRIPTION
## Summary
Fixes the half of #867 that explained why Bob's first live `/api/arm/pick_place` came back as HTTP 200 with three phases of `brain_response="Error: "` and the arm didn't move.

Three error-swallows compounded:
1. **`claude_proxy.py`** wrapped only `result.stderr`, but the Claude CLI writes most auth/runtime errors (expired OAuth token, missing binary, `/login` prompts) to **stdout**. Empty stderr → literally `"Error: "`.
2. **`anthropic_provider.py`** used `f"Error: {e}"` — useless for exceptions whose `__str__` returns empty.
3. **`/api/arm/pick_place`** treated brain failures as "no plan" rather than "brain unavailable," returning 200 with an empty-phase log.

## What changed
- **`castor/claude_proxy.py`** — `stderr → stdout → "<no output, exit code N>"` fallback chain. Every error response now includes the exit code.
- **`castor/providers/anthropic_provider.py`** (both API + CLI paths) — include exception class name + `!r` repr.
- **`castor/api.py`** — `_vision_plan` raises `HTTPException(503)` when `Thought(action=None, raw_text="Error...")`.
- **`tests/test_brain_error_surfacing.py`** — 5 regression tests covering all three layers.

## Out of scope (deferred)
**Bug B** (`consent.scope_threshold: control` not wired to `/api/arm/pick_place`) is intentionally deferred. It needs a separate design pass on mapping RCAN consent block → `HiTLGateManager` registration at startup → endpoint gates. Tracking that as a follow-up; this PR closes the error-surfacing half of #867 only.

## Verification
- `pytest tests/test_brain_error_surfacing.py` — 5/5 pass (all initially failing per TDD)
- `pytest -k "brain or anthropic or claude_proxy or pick_place"` — 187/187 pass, no regressions
- `ruff check castor/claude_proxy.py castor/providers/anthropic_provider.py` — clean
- `ruff format --check` — clean

## Manual repro Bob can now use
After deploy, the same `curl` from #867 will return:
- **503** with `{"error":"Brain unavailable during APPROACH: Error [exit 1]: ..."}` if the OAuth token is expired (instead of a misleading 200)
- The `error` field will name the exception type and include exit-code info, so the operator knows whether to `castor login anthropic` again, install the `claude` CLI, or check connectivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)