### PR TITLE
fix(api,configure): wire RCAN consent.scope_threshold → HiTLGate (#867 Bug B)

### DIFF
--- a/castor/api.py
+++ b/castor/api.py
@@ -2843,6 +2843,12 @@ class _PickPlaceRequest(BaseModel):
     task_id: Optional[str] = None  # Firestore task doc to write progress to
     firebase_project: Optional[str] = None  # Firebase project for task doc writes
     rrn: Optional[str] = None  # Robot RRN for Firestore path
+    # Two-step consent (#867 Bug B). When the RCAN config declares
+    # consent.required=true with scope_threshold>=control, the first call
+    # returns 202 PENDING_AUTH with a pending_id. The operator approves via
+    # POST /api/hitl/authorize, then the client retries this endpoint with
+    # consent_pending_id set to that same pending_id.
+    consent_pending_id: Optional[str] = None
 
 
 @app.post("/api/arm/pick_place", dependencies=[Depends(verify_token)])
@@ -2862,21 +2868,57 @@ async def arm_pick_place(req: _PickPlaceRequest):
     if state.brain is None:
         raise HTTPException(status_code=503, detail="Brain not initialized")
 
-    # Consent gate (#867 Bug B). When the RCAN config declares
-    #   consent: {required: true, scope_threshold: control}
-    # parse_consent_gates() registers a HiTLGate covering "pick_place"
-    # at startup. Block here until the operator authorizes via
-    # POST /api/hitl/authorize, or the gate's timeout/on_timeout policy
-    # rejects the request. No-op when no gate covers pick_place.
-    if state.hitl_gate_manager is not None:
-        _approved = await state.hitl_gate_manager.check(
-            {"type": "pick_place", "target": req.target, "destination": req.destination},
-            thought=None,
-        )
-        if not _approved:
-            raise HTTPException(
-                status_code=403,
-                detail="Consent denied for arm motion (control-scope action)",
+    # Two-step consent gate (#867 Bug B; RCAN §8 / MessageType 10 PENDING_AUTH).
+    # When parse_consent_gates() has registered a HiTLGate covering pick_place:
+    #   • first call (no consent_pending_id) → return 202 PENDING_AUTH + pending_id
+    #   • operator hits POST /api/hitl/authorize with that pending_id
+    #   • client retries with consent_pending_id=<same id> → proceeds (or 403/409)
+    if state.hitl_gate_manager is not None and state.hitl_gate_manager.requires_auth_for(
+        "pick_place"
+    ):
+        if req.consent_pending_id:
+            decision = state.hitl_gate_manager.consume_decision(req.consent_pending_id)
+            if decision == "approve":
+                pass  # fall through into planning loop
+            elif decision == "deny":
+                raise HTTPException(
+                    status_code=403,
+                    detail="Consent denied for arm motion (control-scope action)",
+                )
+            elif state.hitl_gate_manager.is_known_pending(req.consent_pending_id):
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Consent still pending for {req.consent_pending_id}; "
+                        "operator must POST /api/hitl/authorize"
+                    ),
+                )
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Unknown consent_pending_id: {req.consent_pending_id}",
+                )
+        else:
+            # Issue PENDING_AUTH; client retries with the returned id.
+            pending_id = state.hitl_gate_manager.start_pending(
+                {"type": "pick_place", "target": req.target, "destination": req.destination},
+                thought=None,
+            )
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "status": "PENDING_AUTH",
+                    "pending_id": pending_id,
+                    "scope": "control",
+                    "action_type": "pick_place",
+                    "target": req.target,
+                    "destination": req.destination,
+                    "instruction": (
+                        f"POST /api/hitl/authorize with pending_id={pending_id} "
+                        "and decision=approve, then retry this endpoint with "
+                        f"consent_pending_id={pending_id}."
+                    ),
+                },
             )
 
     log: list[dict] = []

--- a/castor/api.py
+++ b/castor/api.py
@@ -2862,6 +2862,23 @@ async def arm_pick_place(req: _PickPlaceRequest):
     if state.brain is None:
         raise HTTPException(status_code=503, detail="Brain not initialized")
 
+    # Consent gate (#867 Bug B). When the RCAN config declares
+    #   consent: {required: true, scope_threshold: control}
+    # parse_consent_gates() registers a HiTLGate covering "pick_place"
+    # at startup. Block here until the operator authorizes via
+    # POST /api/hitl/authorize, or the gate's timeout/on_timeout policy
+    # rejects the request. No-op when no gate covers pick_place.
+    if state.hitl_gate_manager is not None:
+        _approved = await state.hitl_gate_manager.check(
+            {"type": "pick_place", "target": req.target, "destination": req.destination},
+            thought=None,
+        )
+        if not _approved:
+            raise HTTPException(
+                status_code=403,
+                detail="Consent denied for arm motion (control-scope action)",
+            )
+
     log: list[dict] = []
 
     # ── Firestore task progress (best-effort) ─────────────────────────────────
@@ -6194,10 +6211,12 @@ async def on_startup():
 
             # Initialize HiTLGateManager (F3 — HiTL gates)
             try:
-                from castor.configure import parse_hitl_gates
+                from castor.configure import parse_consent_gates, parse_hitl_gates
                 from castor.hitl_gate import HiTLGateManager
 
                 _hgates = parse_hitl_gates(state.config)
+                # Auto-derived gates from the RCAN consent block (#867 Bug B)
+                _hgates.extend(parse_consent_gates(state.config))
                 if _hgates:
                     state.hitl_gate_manager = HiTLGateManager(_hgates)
                     logger.info("HiTLGateManager initialized (%d gates)", len(_hgates))

--- a/castor/configure.py
+++ b/castor/configure.py
@@ -377,3 +377,56 @@ def parse_hitl_gates(config: dict) -> list:
                 "Skipping malformed hitl_gate entry: %s (%s)", g, exc
             )
     return gates
+
+
+# Action types covered when a robot's RCAN config sets `consent.scope_threshold`
+# to the named scope. Wider scopes (lower-trust) include narrower ones.
+#
+# RCAN scope ladder (loosest → strictest):
+#   read  →  command  →  control  →  hardware
+#
+# A robot declaring `scope_threshold: control` is asking for explicit consent
+# on any *control-or-stricter* action (arm motion, gripper close, etc.). A
+# robot declaring `scope_threshold: command` adds command-level actions on top
+# of those.
+_CONSENT_SCOPE_ACTION_TYPES: dict[str, list[str]] = {
+    "control": ["pick_place", "arm_pose", "grip", "set_joint_positions"],
+    "hardware": ["pick_place", "arm_pose", "grip", "set_joint_positions"],
+    "command": ["pick_place", "arm_pose", "grip", "set_joint_positions", "command"],
+}
+
+
+def parse_consent_gates(config: dict) -> list:
+    """Auto-derive HiTL gates from a ``consent`` block in the RCAN config.
+
+    Bridges the gap between the high-level RCAN consent declaration:
+
+        consent:
+          required: true
+          mode: explicit
+          scope_threshold: control
+
+    …and the per-action-type :class:`~castor.hitl_gate.HiTLGate` infrastructure.
+    Returns an empty list when consent is not required or the scope_threshold
+    is below ``control`` (sensor-only scopes don't gate motor action).
+    """
+    from castor.hitl_gate import HiTLGate
+
+    consent = config.get("consent") or {}
+    if not consent.get("required"):
+        return []
+
+    scope = consent.get("scope_threshold")
+    action_types = _CONSENT_SCOPE_ACTION_TYPES.get(scope, [])
+    if not action_types:
+        return []
+
+    return [
+        HiTLGate(
+            action_types=action_types,
+            require_auth=True,
+            auth_timeout_ms=int(consent.get("auth_timeout_ms", 30000)),
+            on_timeout=consent.get("on_timeout", "block"),
+            notify=list(consent.get("notify", [])),
+        )
+    ]

--- a/castor/hitl_gate.py
+++ b/castor/hitl_gate.py
@@ -34,19 +34,40 @@ class HiTLGate:
 
 
 class HiTLGateManager:
-    """Manages HiTL gate lifecycle: pending queue, auth futures, notifications."""
+    """Manages HiTL gate lifecycle: pending queue, auth futures, notifications.
+
+    Supports two flows:
+
+    * **Long-poll** (legacy) — :meth:`check` blocks until the gate resolves
+      via :meth:`authorize` or times out. Single async call from the caller.
+
+    * **Two-step** — :meth:`start_pending` returns a ``pending_id`` immediately
+      without blocking; the caller surfaces it (HTTP 202 body, channel
+      notification, etc.). Once :meth:`authorize` runs, :meth:`consume_decision`
+      atomically yields the resolved decision. Matches RCAN §8 PENDING_AUTH /
+      AUTHORIZE semantics.
+    """
 
     def __init__(self, gates: list[HiTLGate], audit: Any = None):
         self._gates = gates
         self._audit = audit
-        # pending_id -> asyncio.Future[str] ("approve"|"deny")
+        # Long-poll: pending_id -> asyncio.Future[str] ("approve"|"deny")
         self._pending: dict[str, asyncio.Future] = {}
+        # Two-step: pending_ids issued via start_pending(), still unresolved
+        self._known_pending: set[str] = set()
+        # Two-step: resolved decisions waiting for consume_decision()
+        self._resolved: dict[str, str] = {}
 
     def _match_gate(self, action_type: str) -> Optional[HiTLGate]:
         for gate in self._gates:
             if action_type in gate.action_types:
                 return gate
         return None
+
+    def requires_auth_for(self, action_type: str) -> bool:
+        """Return True if any registered gate requires auth for this action type."""
+        gate = self._match_gate(action_type)
+        return gate is not None and gate.require_auth
 
     def _create_pending(self, action: dict, thought: Any) -> str:
         pending_id = str(uuid.uuid4())
@@ -59,6 +80,57 @@ class HiTLGateManager:
             getattr(thought, "id", "?"),
         )
         return pending_id
+
+    def start_pending(self, action: dict, thought: Any = None) -> str:
+        """Create a pending request and return its ID without blocking.
+
+        Returns ``""`` (empty string) when no gate covers this action — caller
+        should treat that as "no consent required, proceed."
+        """
+        action_type = action.get("type", "")
+        gate = self._match_gate(action_type)
+        if gate is None or not gate.require_auth:
+            return ""
+
+        pending_id = str(uuid.uuid4())
+        self._known_pending.add(pending_id)
+        # Loud INFO log so operators tailing gateway logs can see the
+        # pending_id even when channel notify isn't wired (#867 Bug B).
+        logger.info(
+            "HiTL pending (two-step): id=%s action_type=%s notify=%s",
+            pending_id,
+            action_type,
+            gate.notify or "[none]",
+        )
+        # Best-effort channel notify; current _notify only logs but the
+        # hook is here for when channel dispatch lands.
+        try:
+            asyncio.get_event_loop().create_task(
+                self._notify(gate.notify, pending_id, action, thought)
+            )
+        except RuntimeError:
+            # No running loop (e.g. called from sync test setup) — skip notify
+            pass
+        return pending_id
+
+    def consume_decision(self, pending_id: str) -> Optional[str]:
+        """Atomically pop a resolved two-step decision.
+
+        Returns:
+            ``"approve"`` / ``"deny"`` when the operator has authorized;
+            ``None`` when still pending OR when ``pending_id`` is unknown.
+            Distinguish via :meth:`is_known_pending`.
+        """
+        if pending_id not in self._known_pending:
+            return None
+        decision = self._resolved.pop(pending_id, None)
+        if decision in ("approve", "deny"):
+            self._known_pending.discard(pending_id)
+        return decision
+
+    def is_known_pending(self, pending_id: str) -> bool:
+        """Whether this pending_id was issued by :meth:`start_pending`."""
+        return pending_id in self._known_pending
 
     async def _wait_for_auth(self, pending_id: str) -> str:
         future = self._pending.get(pending_id)
@@ -124,16 +196,30 @@ class HiTLGateManager:
     def authorize(self, pending_id: str, decision: Literal["approve", "deny"]) -> bool:
         """Resolve a pending authorization request.
 
+        Resolves whichever flow is active for ``pending_id``:
+
+        * Long-poll: sets the future awaited by :meth:`check`.
+        * Two-step:  stashes the decision for :meth:`consume_decision`.
+
         Args:
-            pending_id: UUID returned when the gate was triggered.
+            pending_id: UUID returned by :meth:`check` (long-poll) or
+                :meth:`start_pending` (two-step).
             decision:   ``"approve"`` or ``"deny"``.
 
         Returns:
-            ``True`` if the pending request was found and resolved.
+            ``True`` if the ``pending_id`` was known to either flow.
         """
+        # Long-poll path
         future = self._pending.get(pending_id)
-        if future is None or future.done():
-            return False
-        future.set_result(decision)
-        logger.info("HiTL authorized: %s -> %s", pending_id, decision)
-        return True
+        if future is not None and not future.done():
+            future.set_result(decision)
+            logger.info("HiTL authorized (long-poll): %s -> %s", pending_id, decision)
+            return True
+
+        # Two-step path
+        if pending_id in self._known_pending:
+            self._resolved[pending_id] = decision
+            logger.info("HiTL authorized (two-step): %s -> %s", pending_id, decision)
+            return True
+
+        return False

--- a/tests/test_consent_gate.py
+++ b/tests/test_consent_gate.py
@@ -1,0 +1,311 @@
+"""Tests for #867 Bug B — wire RCAN consent.scope_threshold → HiTLGate.
+
+bob.rcan.yaml declares:
+
+    consent:
+      required: true
+      mode: explicit
+      scope_threshold: control
+
+…but `/api/arm/pick_place` proceeded without ever consulting the HiTL layer,
+making the declared safety envelope non-load-bearing. These tests cover:
+
+1. configure.parse_consent_gates() — the rcan consent block must produce a
+   HiTLGate covering control-scope action types when required=true.
+2. /api/arm/pick_place must call the gate before the vision-plan loop.
+3. Authorization via the existing /api/hitl/authorize endpoint must
+   unblock a pending pick_place call.
+4. consent.required=false (or missing) must not produce a gate (existing
+   behavior preserved for un-gated configs).
+"""
+
+from __future__ import annotations
+
+import collections
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+# ── 1. parse_consent_gates() ──────────────────────────────────────────────────
+
+
+class TestParseConsentGates:
+    def test_scope_threshold_control_produces_gate(self):
+        from castor.configure import parse_consent_gates
+
+        gates = parse_consent_gates(
+            {
+                "consent": {
+                    "required": True,
+                    "mode": "explicit",
+                    "scope_threshold": "control",
+                }
+            }
+        )
+        assert len(gates) == 1
+        gate = gates[0]
+        assert "pick_place" in gate.action_types
+        assert gate.require_auth is True
+
+    def test_scope_threshold_hardware_also_gates_pick_place(self):
+        from castor.configure import parse_consent_gates
+
+        gates = parse_consent_gates(
+            {
+                "consent": {"required": True, "scope_threshold": "hardware"},
+            }
+        )
+        assert len(gates) == 1
+        assert "pick_place" in gates[0].action_types
+
+    def test_required_false_returns_empty(self):
+        from castor.configure import parse_consent_gates
+
+        gates = parse_consent_gates(
+            {
+                "consent": {"required": False, "scope_threshold": "control"},
+            }
+        )
+        assert gates == []
+
+    def test_no_consent_block_returns_empty(self):
+        from castor.configure import parse_consent_gates
+
+        assert parse_consent_gates({}) == []
+        assert parse_consent_gates({"consent": {}}) == []
+
+    def test_scope_threshold_read_does_not_gate_pick_place(self):
+        """consent.scope_threshold='read' means consent is only required for
+        sensor reads — arm motion (control) should NOT be gated."""
+        from castor.configure import parse_consent_gates
+
+        gates = parse_consent_gates(
+            {
+                "consent": {"required": True, "scope_threshold": "read"},
+            }
+        )
+        # Either no gates, or no gate covering pick_place
+        for gate in gates:
+            assert "pick_place" not in gate.action_types
+
+    def test_unknown_scope_threshold_emits_no_gate_silently(self):
+        from castor.configure import parse_consent_gates
+
+        gates = parse_consent_gates(
+            {
+                "consent": {"required": True, "scope_threshold": "made-up-scope"},
+            }
+        )
+        assert gates == []
+
+
+# ── 2 + 3. /api/arm/pick_place gate integration ───────────────────────────────
+
+
+def _make_client_and_reset(monkeypatch):
+    """Same pattern as tests/test_brain_error_surfacing.py."""
+    monkeypatch.delenv("OPENCASTOR_API_TOKEN", raising=False)
+    monkeypatch.delenv("OPENCASTOR_JWT_SECRET", raising=False)
+
+    import castor.api as api_mod
+
+    api_mod.state.config = None
+    api_mod.state.brain = None
+    api_mod.state.driver = None
+    api_mod.state.channels = {}
+    api_mod.state.last_thought = None
+    api_mod.state.boot_time = time.time()
+    api_mod.state.fs = None
+    api_mod.state.ruri = None
+    api_mod.state.offline_fallback = None
+    api_mod.state.provider_fallback = None
+    api_mod.state.thought_history = collections.deque(maxlen=50)
+    api_mod.state.hitl_gate_manager = None
+    api_mod.API_TOKEN = None
+
+    from starlette.testclient import TestClient
+
+    from castor.api import app
+
+    app.router.on_startup.clear()
+    app.router.on_shutdown.clear()
+
+    import contextlib as _contextlib
+
+    @_contextlib.asynccontextmanager
+    async def _noop_lifespan(app):
+        yield
+
+    app.router.lifespan_context = _noop_lifespan
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _wire_consent_gate(timeout_ms: int = 30000):
+    """Install a HiTLGateManager with a pick_place gate (mimics startup wiring
+    when bob.rcan.yaml has consent.required=true, scope_threshold=control)."""
+    import castor.api as api_mod
+    from castor.configure import parse_consent_gates
+    from castor.hitl_gate import HiTLGateManager
+
+    cfg = {"consent": {"required": True, "scope_threshold": "control"}}
+    gates = parse_consent_gates(cfg)
+    # Tighten timeout so tests finish quickly
+    for g in gates:
+        g.auth_timeout_ms = timeout_ms
+    api_mod.state.hitl_gate_manager = HiTLGateManager(gates)
+
+
+def _wire_brain_that_returns_action(api_mod):
+    """Brain mock that returns one valid arm_pose action so the pick_place
+    loop terminates quickly when the gate approves."""
+    from castor.providers.base import Thought
+
+    mock_brain = MagicMock()
+    mock_brain.think.return_value = Thought(
+        raw_text="[]",
+        action=[],  # empty action list → loop logs but doesn't drive servos
+    )
+    api_mod.state.brain = mock_brain
+
+
+class TestPickPlaceConsentGate:
+    def test_pick_place_blocks_when_consent_required_and_unauthorized(self, monkeypatch):
+        """With consent.required=true (gate registered for pick_place), an
+        unauthorized request must NOT proceed past the consent check."""
+        client = _make_client_and_reset(monkeypatch)
+
+        import castor.api as api_mod
+
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        _wire_consent_gate(timeout_ms=300)  # short timeout so the test isn't slow
+
+        with patch(
+            "castor.api._capture_live_frame",
+            return_value=b"\xff\xd8" + b"\x00" * 1024,
+        ):
+            resp = client.post(
+                "/api/arm/pick_place",
+                json={
+                    "target": "red lego",
+                    "destination": "bowl",
+                    "max_vision_steps": 1,
+                },
+            )
+
+        # Either 403 (denied) or 408 (timeout) — both indicate the gate fired
+        # and refused to proceed. The point is: NOT 200 with phase log.
+        assert resp.status_code in (403, 408, 503), (
+            f"gate did not block: {resp.status_code} {resp.text}"
+        )
+        # And the brain should never have been called (gate is *before* planning)
+        assert api_mod.state.brain.think.call_count == 0, "brain was called despite consent gate"
+
+    def test_pick_place_proceeds_after_authorize(self, monkeypatch):
+        """Operator authorizes via /api/hitl/authorize → blocked pick_place
+        unblocks and progresses into the planning loop."""
+        client = _make_client_and_reset(monkeypatch)
+
+        import castor.api as api_mod
+
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        _wire_consent_gate(timeout_ms=5000)
+
+        # Spawn the pick_place call in a background thread; main thread
+        # polls for the pending gate, hits /api/hitl/authorize, and the
+        # background call should finish 200.
+        result_box: dict = {}
+
+        def _run():
+            with patch(
+                "castor.api._capture_live_frame",
+                return_value=b"\xff\xd8" + b"\x00" * 1024,
+            ):
+                r = client.post(
+                    "/api/arm/pick_place",
+                    json={
+                        "target": "red lego",
+                        "destination": "bowl",
+                        "max_vision_steps": 1,
+                    },
+                )
+            result_box["status"] = r.status_code
+            result_box["body"] = r.text
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+
+        # Wait for the gate manager to register a pending request (up to 1s)
+        manager = api_mod.state.hitl_gate_manager
+        deadline = time.time() + 1.0
+        pending_id = None
+        while time.time() < deadline:
+            if manager._pending:
+                pending_id = next(iter(manager._pending.keys()))
+                break
+            time.sleep(0.02)
+
+        assert pending_id is not None, "no pending HiTL request was created"
+
+        # Authorize via the existing endpoint
+        ar = client.post(
+            "/api/hitl/authorize",
+            json={"pending_id": pending_id, "decision": "approve"},
+        )
+        assert ar.status_code == 200, ar.text
+
+        t.join(timeout=5.0)
+        assert "status" in result_box, "pick_place call did not return"
+        assert result_box["status"] == 200, result_box
+
+    def test_pick_place_proceeds_when_no_consent_gate(self, monkeypatch):
+        """No HiTLGateManager (legacy un-gated config) → endpoint behaves as before."""
+        client = _make_client_and_reset(monkeypatch)
+
+        import castor.api as api_mod
+
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        # Explicitly: no gate manager
+        api_mod.state.hitl_gate_manager = None
+
+        with patch(
+            "castor.api._capture_live_frame",
+            return_value=b"\xff\xd8" + b"\x00" * 1024,
+        ):
+            resp = client.post(
+                "/api/arm/pick_place",
+                json={
+                    "target": "red lego",
+                    "destination": "bowl",
+                    "max_vision_steps": 1,
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+
+    def test_pick_place_proceeds_when_no_pick_place_gate(self, monkeypatch):
+        """HiTLGateManager exists but no gate covers pick_place → no blocking."""
+        client = _make_client_and_reset(monkeypatch)
+
+        import castor.api as api_mod
+        from castor.hitl_gate import HiTLGate, HiTLGateManager
+
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        # Gate covers something else, not pick_place
+        api_mod.state.hitl_gate_manager = HiTLGateManager(
+            [HiTLGate(action_types=["unrelated_grip"], require_auth=True)]
+        )
+
+        with patch(
+            "castor.api._capture_live_frame",
+            return_value=b"\xff\xd8" + b"\x00" * 1024,
+        ):
+            resp = client.post(
+                "/api/arm/pick_place",
+                json={"target": "red lego", "destination": "bowl", "max_vision_steps": 1},
+            )
+
+        assert resp.status_code == 200, resp.text

--- a/tests/test_consent_gate.py
+++ b/tests/test_consent_gate.py
@@ -22,7 +22,6 @@ making the declared safety envelope non-load-bearing. These tests cover:
 from __future__ import annotations
 
 import collections
-import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -169,16 +168,16 @@ def _wire_brain_that_returns_action(api_mod):
 
 
 class TestPickPlaceConsentGate:
-    def test_pick_place_blocks_when_consent_required_and_unauthorized(self, monkeypatch):
-        """With consent.required=true (gate registered for pick_place), an
-        unauthorized request must NOT proceed past the consent check."""
+    def test_first_call_returns_202_pending_auth_with_pending_id(self, monkeypatch):
+        """Two-step / RCAN §8 PENDING_AUTH: first call returns 202 with the
+        pending_id; brain is NEVER invoked at this stage."""
         client = _make_client_and_reset(monkeypatch)
 
         import castor.api as api_mod
 
         api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
         _wire_brain_that_returns_action(api_mod)
-        _wire_consent_gate(timeout_ms=300)  # short timeout so the test isn't slow
+        _wire_consent_gate()
 
         with patch(
             "castor.api._capture_live_frame",
@@ -193,71 +192,164 @@ class TestPickPlaceConsentGate:
                 },
             )
 
-        # Either 403 (denied) or 408 (timeout) — both indicate the gate fired
-        # and refused to proceed. The point is: NOT 200 with phase log.
-        assert resp.status_code in (403, 408, 503), (
-            f"gate did not block: {resp.status_code} {resp.text}"
+        assert resp.status_code == 202, (
+            f"expected 202 PENDING_AUTH, got {resp.status_code}: {resp.text}"
         )
-        # And the brain should never have been called (gate is *before* planning)
-        assert api_mod.state.brain.think.call_count == 0, "brain was called despite consent gate"
+        body = resp.json()
+        assert body["status"] == "PENDING_AUTH"
+        assert body["scope"] == "control"
+        assert body["action_type"] == "pick_place"
+        assert body["pending_id"]  # non-empty UUID
+        # Brain must not have been touched at PENDING_AUTH stage
+        assert api_mod.state.brain.think.call_count == 0, "brain was called pre-auth"
 
-    def test_pick_place_proceeds_after_authorize(self, monkeypatch):
-        """Operator authorizes via /api/hitl/authorize → blocked pick_place
-        unblocks and progresses into the planning loop."""
+    def test_retry_with_unknown_pending_id_returns_400(self, monkeypatch):
+        """Retrying with a pending_id we never issued must reject with 400."""
         client = _make_client_and_reset(monkeypatch)
 
         import castor.api as api_mod
 
         api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
         _wire_brain_that_returns_action(api_mod)
-        _wire_consent_gate(timeout_ms=5000)
+        _wire_consent_gate()
 
-        # Spawn the pick_place call in a background thread; main thread
-        # polls for the pending gate, hits /api/hitl/authorize, and the
-        # background call should finish 200.
-        result_box: dict = {}
+        resp = client.post(
+            "/api/arm/pick_place",
+            json={
+                "target": "red lego",
+                "destination": "bowl",
+                "consent_pending_id": "00000000-not-a-real-id",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert api_mod.state.brain.think.call_count == 0
 
-        def _run():
-            with patch(
-                "castor.api._capture_live_frame",
-                return_value=b"\xff\xd8" + b"\x00" * 1024,
-            ):
-                r = client.post(
-                    "/api/arm/pick_place",
-                    json={
-                        "target": "red lego",
-                        "destination": "bowl",
-                        "max_vision_steps": 1,
-                    },
-                )
-            result_box["status"] = r.status_code
-            result_box["body"] = r.text
+    def test_retry_before_authorize_returns_409(self, monkeypatch):
+        """First call gets pending_id; retrying with that id BEFORE the operator
+        approves must return 409 (still pending)."""
+        client = _make_client_and_reset(monkeypatch)
 
-        t = threading.Thread(target=_run, daemon=True)
-        t.start()
+        import castor.api as api_mod
 
-        # Wait for the gate manager to register a pending request (up to 1s)
-        manager = api_mod.state.hitl_gate_manager
-        deadline = time.time() + 1.0
-        pending_id = None
-        while time.time() < deadline:
-            if manager._pending:
-                pending_id = next(iter(manager._pending.keys()))
-                break
-            time.sleep(0.02)
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        _wire_consent_gate()
 
-        assert pending_id is not None, "no pending HiTL request was created"
+        first = client.post(
+            "/api/arm/pick_place",
+            json={"target": "red lego", "destination": "bowl"},
+        )
+        assert first.status_code == 202
+        pending_id = first.json()["pending_id"]
 
-        # Authorize via the existing endpoint
+        # Don't authorize — retry directly
+        retry = client.post(
+            "/api/arm/pick_place",
+            json={
+                "target": "red lego",
+                "destination": "bowl",
+                "consent_pending_id": pending_id,
+            },
+        )
+        assert retry.status_code == 409, retry.text
+        assert pending_id in retry.json().get("error", retry.text)
+
+    def test_retry_after_deny_returns_403(self, monkeypatch):
+        """Operator denies via /api/hitl/authorize → retry returns 403."""
+        client = _make_client_and_reset(monkeypatch)
+
+        import castor.api as api_mod
+
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        _wire_consent_gate()
+
+        first = client.post(
+            "/api/arm/pick_place",
+            json={"target": "red lego", "destination": "bowl"},
+        )
+        pending_id = first.json()["pending_id"]
+
+        ar = client.post(
+            "/api/hitl/authorize",
+            json={"pending_id": pending_id, "decision": "deny"},
+        )
+        assert ar.status_code == 200, ar.text
+
+        retry = client.post(
+            "/api/arm/pick_place",
+            json={
+                "target": "red lego",
+                "destination": "bowl",
+                "consent_pending_id": pending_id,
+            },
+        )
+        assert retry.status_code == 403, retry.text
+
+    def test_retry_after_approve_proceeds(self, monkeypatch):
+        """Two-step happy path: PENDING_AUTH → /api/hitl/authorize → retry → 200.
+
+        After the operator approves the pending_id, the client retries
+        /api/arm/pick_place with consent_pending_id=<that id> and the brain
+        is called (gate is past, planning loop runs).
+        """
+        client = _make_client_and_reset(monkeypatch)
+
+        import castor.api as api_mod
+
+        api_mod.state.driver = MagicMock(set_joint_positions=MagicMock())
+        _wire_brain_that_returns_action(api_mod)
+        _wire_consent_gate()
+
+        # Step 1: first call → 202 PENDING_AUTH with pending_id
+        first = client.post(
+            "/api/arm/pick_place",
+            json={
+                "target": "red lego",
+                "destination": "bowl",
+                "max_vision_steps": 1,
+            },
+        )
+        assert first.status_code == 202, first.text
+        pending_id = first.json()["pending_id"]
+        assert api_mod.state.brain.think.call_count == 0
+
+        # Step 2: operator approves
         ar = client.post(
             "/api/hitl/authorize",
             json={"pending_id": pending_id, "decision": "approve"},
         )
         assert ar.status_code == 200, ar.text
 
-        t.join(timeout=5.0)
-        assert "status" in result_box, "pick_place call did not return"
-        assert result_box["status"] == 200, result_box
+        # Step 3: client retries with consent_pending_id → proceeds into loop
+        with patch(
+            "castor.api._capture_live_frame",
+            return_value=b"\xff\xd8" + b"\x00" * 1024,
+        ):
+            retry = client.post(
+                "/api/arm/pick_place",
+                json={
+                    "target": "red lego",
+                    "destination": "bowl",
+                    "max_vision_steps": 1,
+                    "consent_pending_id": pending_id,
+                },
+            )
+
+        assert retry.status_code == 200, retry.text
+        # Brain WAS called now (gate is past)
+        assert api_mod.state.brain.think.call_count >= 1
+
+        # And the pending_id is single-use: replaying it should now 400
+        replay = client.post(
+            "/api/arm/pick_place",
+            json={
+                "target": "red lego",
+                "destination": "bowl",
+                "consent_pending_id": pending_id,
+            },
+        )
+        assert replay.status_code == 400, replay.text
 
     def test_pick_place_proceeds_when_no_consent_gate(self, monkeypatch):
         """No HiTLGateManager (legacy un-gated config) → endpoint behaves as before."""


### PR DESCRIPTION
## Summary
Closes the second half of #867. `bob.rcan.yaml` declares:

```yaml
consent:
  required: true
  mode: explicit
  scope_threshold: control
```

…but `/api/arm/pick_place` proceeded straight into planning without ever consulting the HiTL layer. The declared safety envelope was non-load-bearing.

## Approach: two-step PENDING_AUTH (RCAN §8 / MessageType 10)
Pivoted from the original long-poll implementation per the literal text of the issue body — *"the first call on a session should return a PENDING_AUTH response, operator authorizes, and only then does the pick-place loop run."*

| Step | Client | Server |
|------|--------|--------|
| 1 | `POST /api/arm/pick_place {target, destination}` | `202 {"status":"PENDING_AUTH","pending_id":"...","scope":"control",...}` |
| 2 | (operator) | `POST /api/hitl/authorize {pending_id, decision:"approve"}` → 200 |
| 3 | `POST /api/arm/pick_place {target, destination, consent_pending_id:<same id>}` | proceeds into planning loop → 200 |

Long-poll path via `HiTLGateManager.check()` is preserved unchanged for backward compat with `test_hitl_gate.py` and any other callers.

## Behavior matrix
| Scenario | Response |
|----------|----------|
| no `consent` block | unchanged (legacy un-gated) |
| `consent.required: false` | unchanged |
| `consent.required: true, scope_threshold: read` | unchanged (sensor-only scope, motor unaffected) |
| First call, no `consent_pending_id` | **202** PENDING_AUTH + pending_id |
| Retry with known + approved id | **200** (brain called) |
| Retry with known + denied id | **403** |
| Retry with known + still-pending id | **409** |
| Retry with unknown id | **400** |
| Replay an already-consumed id | **400** (single-use) |

## Changes
- **`castor/hitl_gate.py`** — `HiTLGateManager` gains `start_pending`, `consume_decision`, `is_known_pending`, `requires_auth_for`. `authorize()` resolves either flow.
- **`castor/api.py`** — `_PickPlaceRequest` gets `consent_pending_id: Optional[str]`. Endpoint implements the two-step state machine.
- **`castor/configure.py`** — new `parse_consent_gates(config)` mapping the RCAN `consent` block to `HiTLGate` instances. Wired into startup.
- **`tests/test_consent_gate.py`** — 13 regression tests covering every branch.

## Verification
- `pytest tests/test_consent_gate.py tests/test_hitl_gate.py` — 20/20 pass
- `pytest -k "consent or hitl or pick_place or configure or brain"` — 261 passed, 1 skipped, no regressions
- `ruff check` + `ruff format --check` — clean

## Out of scope (tracked as follow-up)
`HiTLGate.notify` (channel dispatch on pending_id) is a cross-cutting OpenCastor concern — `authority.py:_notify_owner` and `hitl_gate.py:_notify` have the same `notify_fn=None` / log-only gap. With the two-step model the pending_id is in the 202 body so upstream callers (chat handlers, UIs) already have what they need to surface it. Real channel-side wiring deserves its own PR.

Together with PR #879 (Bug A — error swallow), this closes #867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
