### PR TITLE
ci: forbidden-phrase-lint workflow (Plan 2 Phase 4 PR 3)

### DIFF
--- a/.github/workflows/forbidden-phrase-lint.yml
+++ b/.github/workflows/forbidden-phrase-lint.yml
@@ -1,0 +1,49 @@
+name: forbidden-phrase-lint
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'CLAUDE.md'
+      - 'CHANGELOG.md'
+      - 'docs/**'
+      - 'website/**'
+      - '.github/workflows/forbidden-phrase-lint.yml'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Fetch lint + dictionary from opencastor-ops
+        env:
+          AUTH_TOKEN: ${{ secrets.OPENCASTOR_OPS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/craigm26/opencastor-ops/contents"
+          REF="master"
+          mkdir -p .forbidden-phrase-lint
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/tools/lint_forbidden_phrases.py?ref=${REF}" \
+            -o .forbidden-phrase-lint/lint.py
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/docs/standards/forbidden-phrases.json?ref=${REF}" \
+            -o .forbidden-phrase-lint/dict.json
+      - name: Run lint
+        run: |
+          set -euo pipefail
+          python .forbidden-phrase-lint/lint.py \
+            --dict .forbidden-phrase-lint/dict.json \
+            --root .


### PR DESCRIPTION
## Summary

Phase 4 PR 3 of Plan 2 (Documentation Accuracy Pass). Adds the `forbidden-phrase-lint` CI gate to OpenCastor — same inline-form template that rcan-spec (PR #206) and RRF (PR #81) ship.

The workflow runs on every PR that touches a marketing/docs surface (`README.md`, `CLAUDE.md`, `CHANGELOG.md`, `docs/**`, `website/**`, the workflow file). It fetches the lint script + canonical phrase dictionary from `craigm26/opencastor-ops` master via the GitHub Contents API authed with `OPENCASTOR_OPS_READ_TOKEN` (PAT already provisioned), then runs `lint_forbidden_phrases.py --root .`.

Backend code (`castor/`, `sdk/`, `tests/`, `config/`) is intentionally out of scope — the lint targets honesty/version-discipline on user-facing surfaces only.

## Why inline form (not composite action)

Composite-action consumption from a private cross-owner repo is not possible — GitHub rejects `uses: craigm26/opencastor-ops/.github/actions/...@master` at workflow validation because action resolution uses the consumer's ephemeral `GITHUB_TOKEN`, which is not scoped to opencastor-ops. Phase 1 verified this on robot-md PR #40. Inline form is the canonical shape.

## Test plan

- [ ] First push triggers the workflow
- [ ] Workflow run is green (clean tree from PR #887 merge)
- [ ] Job duration is ~10-15s (parity with rcan-spec/RRF first runs)

Refs spec §10 + §8 + §3.