### PR TITLE
chore(ci): bump emit-version-tuple to v3.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: opencastor
           ran: ${{ secrets.OPENCASTOR_RELEASE_RAN }}
@@ -340,7 +340,7 @@ jobs:
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: opencastor
           ran: ${{ secrets.OPENCASTOR_RELEASE_RAN }}


### PR DESCRIPTION
## Summary
- Bump `continuonai/rcan-spec/.github/actions/emit-version-tuple` pin from v3.2.0 to v3.2.3 (release.yml, both publish + backfill jobs).
- v3.2.3 (rcan-spec [PR #209](https://github.com/continuonai/rcan-spec/pull/209), `feb92cb`) adds `--repo "${{ github.repository }}"` to `gh release upload`, fixing the `fatal: not a git repository` failure in checkout-less publish jobs.

## Test plan
- [ ] CI green on this PR
- [ ] Next OpenCastor release tag: emit-version-tuple step exits 0 and attaches the signed envelope to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)