### PR TITLE
release: v3.0.2 — Plan 6 Phase 1 verification marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions switched from date-based (`YYYY.MM.DD.patch`) to SemVer at
 
 ---
 
+## [3.0.2] - 2026-05-03
+
+### Verified
+
+Plan 6 Phase 1 (cert tracks) verification re-run — re-ran the OpenCastor
+conformance + compliance suites against the post-freeze rcan-spec from
+Plan 1. All 195 tests across `test_conformance*.py` + `test_compliance.py`
++ `test_rcan3_compliance.py` pass on current main against rcan-spec
+master `c9f2d1f`. No code changes; this release memorializes the
+verification outcome with a signed version-tuple envelope, which is
+also the first canary of the rcan-spec emit-version-tuple action's
+v3.2.3 `--repo` fix from Plan 4 Phase 0.
+
+---
+
 ## [3.0.1] - 2026-04-24
 
 ### Fixed — R6 demo-day gaps

--- a/castor/__init__.py
+++ b/castor/__init__.py
@@ -7,7 +7,7 @@ try:
 
     __version__ = _pkg_version("opencastor")
 except Exception:
-    __version__ = "3.0.1"  # fallback
+    __version__ = "3.0.2"  # fallback
 
 
 def initialize_safety(safety_layer, config: dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opencastor"
-version = "3.0.1"
+version = "3.0.2"
 description = "The Universal Runtime for Embodied AI"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Plan 6 Phase 1 (cert tracks) verification re-run release. Bumps version 3.0.1 → 3.0.2.

**No code changes.** This release exists to memorialize the conformance verification outcome with a signed version-tuple envelope, and to canary the rcan-spec emit-version-tuple action `--repo` fix from Plan 4 Phase 0.

## Verification done
- `.venv/bin/pytest tests/test_conformance.py tests/test_conformance_v3.py tests/test_conformance_v3_slice2.py tests/test_rcan3_compliance.py tests/test_compliance.py -v`
- 195/195 pass on current main against rcan-spec master `c9f2d1f`.

## On merge
The release.yml workflow will:
1. Publish opencastor 3.0.2 to PyPI (OIDC trusted publisher).
2. Emit a signed version-tuple envelope via `emit-version-tuple@v3.2.3` (the action that just got the `--repo` fix in rcan-spec PR #209). This is the first end-to-end canary of that fix on a real release.
3. Attach the signed envelope to the GitHub release.

## Test plan
- [x] Conformance + compliance suites pass locally
- [ ] CI green
- [ ] PyPI 3.0.2 published
- [ ] Signed envelope `version-tuple-envelope-cli_version.json` attached to v3.0.2 release
- [ ] emit-version-tuple step exits 0 (no `fatal: not a git repository` regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)