### PR TITLE
docs(apex): Plan 9 Phase 5 — drop stale version pins, retire "informed the spec" framing, soften EU AI Act claim

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -13,12 +13,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <!-- ======== HERO ======== -->
 <section class="hero">
   <div class="hero-card reveal">
-    <div class="hero-status-bar">
-      <div class="badge status-version">
-        v2026.3.27.1
-      </div>
-    </div>
-
     <!-- Phase 8: Prominent Brand Identifier -->
     <div class="hero-brand-logo reveal">
       <img src="/assets/icon-128.png" alt="OpenCastor Icon" width="64" height="64" />
@@ -30,7 +24,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </h1>
 
     <p class="hero-sub reveal-d2">
-      Give any robot a brain. Semantic perception with local embeddings, 13+ AI providers,<br>
+      Give any robot a brain. Semantic perception with local embeddings, 12+ AI providers,<br>
       HLabs ACB · LiDAR · IMU · depth cameras · reactive obstacle avoidance. One config file. Zero lock-in.
     </p>
 
@@ -150,7 +144,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div class="card reveal reveal-d2">
         <div class="card-icon" style="background: var(--orange-light);">🛡️</div>
         <h3>Safety &amp; AI Accountability</h3>
-        <p>Multi-layered safety kernel: anti-subversion defense, work authorization, physical bounds enforcement, tamper-evident audit logs, and emergency stop in every loop. RCAN §16 AI Accountability: every command carries model identity, confidence gates, and Human-in-the-Loop authorization — EU AI Act ready.</p>
+        <p>Multi-layered safety kernel: anti-subversion defense, work authorization, physical bounds enforcement, tamper-evident audit logs, and emergency stop in every loop. RCAN §16 AI Accountability: every command carries model identity, confidence gates, and Human-in-the-Loop authorization — produces evidence for EU AI Act compliance assessments.</p>
       </div>
 
       <div class="card reveal reveal-d3">
@@ -370,7 +364,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <section class="section" id="release">
   <div class="container">
     <div class="section-header center reveal">
-      <p class="section-label">v2026.3.27.1 — March 27, 2026</p>
+      <p class="section-label">Recent Releases</p>
       <h2 class="section-title">What's New</h2>
     </div>
     <div class="feature-grid">
@@ -414,7 +408,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <a href="https://rcan.dev" style="color: var(--accent); text-decoration: none; font-weight: 600;">RCAN</a> is an independent open protocol — the proposed standard for robot identity, accountability, and communication. Think of it like DNS and ICANN, but for robotics. Any robot, any runtime, any manufacturer can implement RCAN and register at the <a href="https://robotregistryfoundation.org/registry/" style="color: var(--accent); text-decoration: none;">Robot Registry Foundation</a>.
       </p>
       <p style="margin-bottom: 1.2rem;">
-        OpenCastor is a productized open-core RCAN runtime — the runtime that helped inform and test the spec. RCAN-the-protocol is implementation-independent; OpenCastor is the most fully-documented runtime that speaks it. You don't need OpenCastor to use RCAN. You don't need RCAN to use OpenCastor. Using both together is encouraged and gives you the full stack: a robot that is controllable, auditable, and globally addressable.
+        OpenCastor is a productized open-core RCAN runtime. RCAN-the-protocol is implementation-independent; OpenCastor is the most fully-documented runtime that speaks it. You don't need OpenCastor to use RCAN. You don't need RCAN to use OpenCastor. Using both together is encouraged and gives you the full stack: a robot that is controllable, auditable, and globally addressable.
       </p>
       <p>
         If you're building a robot runtime, a fleet management system, or robotics hardware — <strong style="color: var(--text, #f1f5f9);">you are welcome and encouraged to implement RCAN</strong>. The spec is CC BY 4.0. The registry is open to all robots.


### PR DESCRIPTION
## Summary

Plan 9 Phase 5 — final phase, closes the 5-site apex text-accuracy work block. Single-file fix in `website/src/pages/index.astro` applying 5 findings from
[`operations/2026-05-05-apex-text-accuracy/findings-opencastor-apex.md`](https://github.com/craigm26/opencastor-ops/blob/master/operations/2026-05-05-apex-text-accuracy/findings-opencastor-apex.md)
in the opencastor-ops audit repo.

**Scope correction:** Plan 9 README listed `craigm26/opencastor-docs` as the apex repo. Verified via `repos.json` that `craigm26/OpenCastor` is the apex (`opencastor.com`); `opencastor-docs` is the docs subdomain (covered by Plan 8). Audit ran on `~/OpenCastor/website/`.

## Findings landed in this PR

### Factual (2)

- **[F-OCD-01]** `website/src/pages/index.astro:417` — Drop "the runtime that helped inform and test the spec" clause. Same F-01-pattern semantic blind-spot caught in Phase 1 F-01 (rcan-spec/about.astro:103-105). Spec §3 Decision 2 retires "informed the spec" implication of directional dependency from runtime → spec; RCAN is implementation-independent. The next sentence ("RCAN-the-protocol is implementation-independent; OpenCastor is the most fully-documented runtime that speaks it") already conveys the canonical relationship.
- **[F-OCD-04]** `website/src/pages/index.astro:153` — "EU AI Act ready" → "produces evidence for EU AI Act compliance assessments." Per [`docs/standards/disclaimers/regulatory.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/standards/disclaimers/regulatory.md): "Compliance packet generation and RRF submission produce *evidence*; they do not constitute regulatory sufficiency." (Compare line 386 "EU AI Act Art. 16(j) authority access" — a feature label, not a readiness claim — which is fine and untouched.)

### Drift (3)

- **[F-OCD-02]** `website/src/pages/index.astro:18` — Drop hero version badge `v2026.3.27.1` entirely (CalVer ~6 weeks stale). Same "drop the pin everywhere" decision applied to opencastor-client PR #128 follow-up commit `0533187`. The hero install command (line 49 `curl -sL opencastor.com/install | bash`) is already version-agnostic; the badge added no information beyond "this site exists."
- **[F-OCD-03]** `website/src/pages/index.astro:373` — "What's New" section label `v2026.3.27.1 — March 27, 2026` → `Recent Releases`. The per-release cards inside the section (lines 379, 385, 391) keep their own version annotations as legitimate historical references (akin to changelog entries; not touched).
- **[F-OCD-05]** `website/src/pages/index.astro:33` — "13+ AI providers" → "12+ AI providers". Aligns with the rest of the page (lines 7, 72, 283-292) + `BaseLayout.astro:14`. The provider list (lines 74-86) contains 12 entries.

## P0 save during Phase 5 prep

About-to-apply F-OCD-02 with `3.0.1` SemVer pin would have repeated the broken-pin failure mode of opencastor-client PR #128 (now fixed in `0533187`). Caught by advisor before edit. Verified live (2026-05-08):

| Source | OpenCastor version |
|---|---|
| PyPI latest (`/pypi/opencastor/json`) | `2026.4.23.0` (CalVer) |
| `pyproject.toml` (this repo) | `3.0.2` (SemVer; **not on PyPI**) |
| `CHANGELOG.md` | "switched from CalVer to SemVer at 3.0.0" |
| `CLAUDE.md` (this repo) | "Version: 2026.4.17.0 (CalVer)" — self-contradicts CHANGELOG |
| `opencastor-ops/config/repos.json` | `opencastor_version: "3.0.1"` |

Underlying versioning-scheme conflict logged as **S-OCD-D** for separate strategic resolution (out of Plan 9 text-accuracy scope).

## Stylistic / out-of-scope findings deferred (5 sub-findings)

A separate follow-up issue covers each:

- **[S-OCD-A]** `blog/index.astro` has no post since March 26, 2026 — drift is *missing content* (no v3.2 release post or banner), not wrong text. Out of Plan 9 text-accuracy.
- **[S-OCD-B]** Per-feature "since vX" annotations on `hardware.astro` (4 driver cards, lines 245, 253, 261, 269) — same pattern as Phase 4 S-OCC-A (opencastor-client#129); each requires human review (historical fact vs current-state claim).
- **[S-OCD-C]** Point-in-time stats numbers (`index.astro` 166,186 LOC / 6,404 tests / 12 providers; `about.astro:146` "Protocol 66 conformance reached 94%"). CLAUDE.md says **7,804+ tests** today — drifted by ~1,400. Needs fresh data, not text edit.
- **[S-OCD-D]** Ecosystem versioning-scheme conflict (table above) — strategic operator decision.
- **[S-OCD-E]** `opencastor-ops/docs/standards/forbidden-phrases.json` should allowlist `website/src/pages/blog/` (parallel to existing `src/pages/changelog.astro` allowlist) so the 18 historical-blog-post lint hits stop firing forever — single-line opencastor-ops PR.

## Verification

- [x] `npx astro build` — 84 pages built clean. No errors.
- [x] `python3 tools/lint_forbidden_phrases.py --root ~/OpenCastor/website` — 18 hits (unchanged baseline; all in 5 historical blog post bodies; deferred to S-OCD-E systemic allowlist). Apex pages: 0 hits.
- [x] `grep -nE "v2026\.3\.27\.1|13\+ AI providers|EU AI Act ready|helped inform and test the spec" website/src/pages/index.astro` — 0 hits in marketing surfaces (the 2 remaining hits on lines 373 and 375 are inside a per-release CARD, which is a legitimate historical reference like a changelog entry).
- [x] Manual diff review — 1 file, +4/-10 (clean concise edit).

## Phase 1-4 sibling PRs (Plan 9 work block)

This PR closes Plan 9 (final phase). Sibling PRs:

- [continuonai/rcan-spec#210](https://github.com/continuonai/rcan-spec/pull/210) — Phase 1 F-01 carryover (rcan.dev about page).
- [craigm26/RobotRegistryFoundation#92](https://github.com/craigm26/RobotRegistryFoundation/pull/92) — Phase 2 RRF apex (6 findings).
- [RobotRegistryFoundation/robot-md#46](https://github.com/RobotRegistryFoundation/robot-md/pull/46) — Phase 3 robotmd.dev (8 findings).
- [craigm26/opencastor-client#128](https://github.com/craigm26/opencastor-client/pull/128) — Phase 4 app.opencastor.com (8 findings + follow-up `0533187` for the broken-pin save).

All 5 PRs are independent (different files, different repos); none blocks the other.

## Spec / Plan references

- North star: [`docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md) §3 Decision 2 (retire "reference implementation of RCAN" entirely; canonical Layer-4 silo charter)
- Canonical strategy: [`business/2026-05-08-strategy-canonical.md`](https://github.com/craigm26/opencastor-ops/blob/master/business/2026-05-08-strategy-canonical.md) §3 (Layer-4 charter for OpenCastor)
- Regulatory disclaimer: [`docs/standards/disclaimers/regulatory.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/standards/disclaimers/regulatory.md) (compliance packet ≠ regulatory sufficiency — basis for F-OCD-04)
- Forbidden-phrase dict: [`docs/standards/forbidden-phrases.json`](https://github.com/craigm26/opencastor-ops/blob/master/docs/standards/forbidden-phrases.json) — `reference-implementation-of-rcan` regex blind-spot for the F-OCD-01 variant; `rcan-version-hardcoded` covers the dropped `v2026.3.27.1` pins
- Plan 8 redirects: `website/public/_redirects` confirms `/docs/*` → `docs.opencastor.com`; apex pages don't host docs prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)