### PR TITLE
docs(claude-md): replace pinned RCAN v3.0 with link to compatibility matrix (Plan 9 carryover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 OpenCastor is an open-source **productized open-core RCAN runtime** — Layer 4 of the OpenCastor stack. It connects LLM "brains" to robot "bodies" through a plug-and-play architecture and exposes them to messaging platforms for remote control.
 
 - **Version**: 2026.4.17.0 (date-based: `YYYY.MM.DD.patch`)
-- **RCAN**: v3.0 — see [rcan.dev/spec](https://rcan.dev/spec/)
+- **RCAN**: see [rcan.dev/compatibility](https://rcan.dev/compatibility) for canonical version (`rcan_spec_version` in `opencastor-ops/config/repos.json`: 3.2)
 - **License**: Apache 2.0 | **Python**: 3.10+ | **Tests**: 7804+ passing
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Plan 9 [lessons-learned doc](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) open question §4 (cross-repo CLAUDE.md drift sweep). 1-line fix.

## Drift

Line 10 of `CLAUDE.md`:

```diff
- - **RCAN**: v3.0 — see [rcan.dev/spec](https://rcan.dev/spec/)
+ - **RCAN**: see [rcan.dev/compatibility](https://rcan.dev/compatibility) for canonical version (`rcan_spec_version` in `opencastor-ops/config/repos.json`: 3.2)
```

`v3.0` was 2 minor versions stale; canonical per `opencastor-ops/config/repos.json` is `rcan_spec_version: "3.2"`. Per [Plan 9 lessons §A](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) (pin will drift again on next spec bump) and [§H](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) (verification anchors — link to live source beats pinning), the fix is to link rather than re-pin.

## NOT in this PR

Line 9 (`Version: 2026.4.17.0` CalVer) is **intentionally not touched**. Three sources disagree:

- This CLAUDE.md says CalVer.
- `CHANGELOG.md` says "switched from CalVer to SemVer at 3.0.0."
- `pyproject.toml` is `3.0.2`.
- PyPI latest is `2026.4.23.0` (CalVer; SemVer 3.0.x not yet published).

Tied to Plan 9 cross-cutting deferred item **S-OCD-D** (tracked on [#895](https://github.com/craigm26/OpenCastor/issues/895)). Resolution requires an operator strategic decision spanning this repo + `opencastor-ops/config/repos.json` + a PyPI publish action — out of scope for a one-line CLAUDE.md fix.

## Sister PRs (same drift class)

- `opencastor-ops` master `f9bfd1b` (direct commit; SPEC_VERSION 3.0 → 3.2 + canonical pkg names)
- [craigm26/opencastor-client#132](https://github.com/craigm26/opencastor-client/pull/132) (5 stale ecosystem-table facts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)