### PR TITLE
chore(ci): point rcan-spec action ref at RobotRegistryFoundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
+      - uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: opencastor
           ran: ${{ secrets.OPENCASTOR_RELEASE_RAN }}
@@ -340,7 +340,7 @@ jobs:
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
+      - uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: opencastor
           ran: ${{ secrets.OPENCASTOR_RELEASE_RAN }}


### PR DESCRIPTION
Re-point the `emit-version-tuple` CI action from `continuonai/rcan-spec` to
`RobotRegistryFoundation/rcan-spec`, as part of moving the RCAN spec to the Robot
Registry Foundation. No behaviour change — same action, same `@v3.2.3` tag, new
owner.

⚠️ Merge only AFTER `rcan-spec` has been transferred to RobotRegistryFoundation,
or this repo's next release will fail to resolve the action.
