### PR TITLE
castor pair (iOS pairing QR + attestation) + fix PyPI CalVer install trap

### DIFF
--- a/castor/cli.py
+++ b/castor/cli.py
@@ -3506,6 +3506,109 @@ def cmd_setup(args) -> None:
     _print("")
 
 
+def cmd_pair(args) -> int:
+    """castor pair — print the iOS app's pairing QR + wire gateway attestation.
+
+    Generates an Ed25519 attestation identity, wires it into the gateway's env
+    config (ROBOT_MD_ATTESTATION_KEY_FILE + _KID so /v1/invoke returns signed
+    receipts), and prints a scannable QR encoding
+    {v, gateway_url, bearer, manifest_path, rrn, estop_url?}.
+    """
+    import json as _json
+    from pathlib import Path
+
+    from castor import pairing
+
+    manifest_path = Path(args.manifest_path).expanduser()
+    if not manifest_path.exists():
+        print(f"error: manifest (ROBOT.md) not found: {manifest_path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    # gateway_url — explicit flag wins, else best-effort LAN URL.
+    gateway_url = args.gateway_url or pairing.default_gateway_url(port=args.port)
+
+    # bearer — explicit flag wins, else read the actuate-tier token from a
+    # bearers.yaml (flag, or one sitting next to the manifest).
+    bearer = args.bearer or ""
+    if not bearer:
+        bearers_path = Path(args.bearers).expanduser() if args.bearers else (
+            manifest_path.parent / "bearers.yaml"
+        )
+        if bearers_path.exists():
+            try:
+                bearer = pairing.read_bearer_from_bearers_yaml(bearers_path)
+            except (ValueError, OSError) as exc:
+                print(f"error: could not read bearer from {bearers_path}: {exc}", file=sys.stderr)
+                raise SystemExit(1)
+        else:
+            print(
+                "error: no bearer token. Pass --bearer TOKEN or --bearers path/to/bearers.yaml "
+                "(run `robot-md-gateway init` to create one).",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    # rrn — explicit flag wins, else parse it out of the ROBOT.md frontmatter.
+    rrn = args.rrn or pairing.read_rrn_from_manifest(manifest_path)
+    if not rrn:
+        print(
+            "error: could not determine RRN. Pass --rrn RRN-... or add metadata.rrn to the "
+            "ROBOT.md.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    # Where the attestation key + env config land.
+    key_file = (
+        Path(args.key_file).expanduser()
+        if args.key_file
+        else Path.home() / ".config" / "opencastor" / "attestation" / "gateway-attestation.pem"
+    )
+    env_file = (
+        Path(args.env_file).expanduser()
+        if args.env_file
+        else Path.home() / ".config" / "opencastor" / "gateway-attestation.env"
+    )
+
+    try:
+        result = pairing.run_pair(
+            manifest_path=manifest_path,
+            gateway_url=gateway_url,
+            bearer=bearer,
+            rrn=rrn,
+            key_file=key_file,
+            env_file=env_file,
+            kid=args.kid,
+            estop_url=args.estop_url,
+            force=args.force,
+        )
+    except FileExistsError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    payload_json = _json.dumps(result.payload)
+
+    print("\nScan this QR from the OpenCastor iOS app to pair:\n")
+    _print_qr(payload_json)
+    print()
+    print("Pairing payload (decoded):")
+    print(_json.dumps(result.payload, indent=2))
+    print()
+    print("Gateway attestation wired:")
+    print(f"  key file : {result.identity.key_file}")
+    print(f"  kid      : {result.identity.kid}")
+    print(f"  env file : {result.env_file}")
+    print()
+    print("Start (or restart) the gateway with attestation enabled:")
+    print(f"  set -a; . {result.env_file}; set +a")
+    print("  robot-md-gateway serve \\")
+    print(f"    --robot-md {result.payload['manifest_path']} \\")
+    print("    --bearers /path/to/bearers.yaml --host 0.0.0.0 --port "
+          f"{args.port}")
+    print()
+    return 0
+
+
 def cmd_fleet_link(args) -> None:
     """castor fleet-link — generate Fleet UI deep links and QR codes for this robot."""
 
@@ -8679,6 +8782,61 @@ def main() -> None:
         help="Accept all defaults without prompting (for CI/Docker)",
     )
 
+    # castor pair — pairing QR for the iOS app + gateway attestation wiring
+    p_pair = sub.add_parser(
+        "pair",
+        help="Print the iOS app pairing QR and wire gateway attestation (T-002)",
+        epilog=(
+            "Examples:\n"
+            "  castor pair --manifest-path /home/pi/ROBOT.md --bearers ./bearers.yaml\n"
+            "  castor pair --manifest-path ./ROBOT.md --gateway-url http://robot.local:8080 \\\n"
+            "              --bearer $TOKEN --rrn RRN-000000000011\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_pair.add_argument(
+        "--manifest-path",
+        required=True,
+        help="Gateway-host-local path to the ROBOT.md the app actuates against (rides in the QR)",
+    )
+    p_pair.add_argument(
+        "--gateway-url",
+        default=None,
+        help="Gateway base URL (default: best-effort LAN URL http://<lan-ip>:<port>)",
+    )
+    p_pair.add_argument("--port", type=int, default=8080, help="Gateway port for the default URL")
+    p_pair.add_argument("--bearer", default=None, help="Bearer token to embed (else read --bearers)")
+    p_pair.add_argument(
+        "--bearers",
+        default=None,
+        help="Path to bearers.yaml to read the actuate token from "
+        "(default: bearers.yaml next to the ROBOT.md)",
+    )
+    p_pair.add_argument(
+        "--rrn",
+        default=None,
+        help="Robot RRN (default: parsed from the ROBOT.md metadata.rrn)",
+    )
+    p_pair.add_argument("--estop-url", default=None, help="Optional software e-stop URL for the QR")
+    p_pair.add_argument(
+        "--key-file",
+        default=None,
+        help="Where to write the Ed25519 attestation key "
+        "(default: ~/.config/opencastor/attestation/gateway-attestation.pem)",
+    )
+    p_pair.add_argument(
+        "--env-file",
+        default=None,
+        help="Env file to write ROBOT_MD_ATTESTATION_KEY_FILE/_KID into "
+        "(default: ~/.config/opencastor/gateway-attestation.env)",
+    )
+    p_pair.add_argument("--kid", default=None, help="Override the attestation kid (default: derived)")
+    p_pair.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing attestation key (rotates the identity)",
+    )
+
     # castor fleet-link — Fleet UI deep links and QR codes
     p_fleet_link = sub.add_parser(
         "fleet-link",
@@ -9013,6 +9171,8 @@ def main() -> None:
         "bridge": _cmd_bridge,
         # Fleet UI onboarding wizard
         "setup": cmd_setup,
+        # iOS app pairing QR + gateway attestation wiring (T-002)
+        "pair": cmd_pair,
         # Fleet UI deep links + QR codes
         "fleet-link": cmd_fleet_link,
         # Agent harness: skill evaluation

--- a/castor/pairing.py
+++ b/castor/pairing.py
@@ -1,0 +1,270 @@
+"""castor pair — generate the iOS app's pairing QR + wire gateway attestation.
+
+This bridges the robot-md-gateway (T-001 signed receipts) to the OpenCastor iOS
+app. `castor pair`:
+
+  1. Generates an Ed25519 attestation identity (the SAME throwaway approach the
+     gateway uses for its own signing key: ``Ed25519PrivateKey.generate()`` ->
+     PKCS8 PEM, ``NoEncryption``) and writes the private key to disk (0600).
+  2. Wires it into the gateway's env config by setting
+     ``ROBOT_MD_ATTESTATION_KEY_FILE`` and ``ROBOT_MD_ATTESTATION_KID`` — the exact
+     variables ``robot_md_gateway.attestation.load_signing_identity_from_env`` reads
+     so that /v1/invoke starts returning signed receipts.
+  3. Builds the pairing QR payload
+     ``{v, gateway_url, bearer, manifest_path, rrn, estop_url?}``. ``manifest_path``
+     MUST ride in the QR: it is a gateway-host-local filesystem path the
+     InvokeEnvelope requires and the client cannot guess.
+
+Pure logic lives here (no argparse, no printing) so it is unit-testable; the
+``castor pair`` CLI glue in ``castor/cli.py`` calls ``run_pair`` then renders the
+QR + JSON.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# The two env vars the gateway's attestation loader consumes. Kept as module
+# constants so the test asserts against the same strings the gateway reads.
+ATTESTATION_KEY_FILE_ENV = "ROBOT_MD_ATTESTATION_KEY_FILE"
+ATTESTATION_KID_ENV = "ROBOT_MD_ATTESTATION_KID"
+
+# QR payload schema version. The iOS app (T-012) parses on this.
+PAIR_PAYLOAD_VERSION = 1
+
+
+@dataclass(frozen=True)
+class AttestationIdentity:
+    """A freshly-generated gateway attestation identity."""
+
+    key_file: Path
+    kid: str
+    pub_file: Path
+
+
+@dataclass(frozen=True)
+class PairResult:
+    """Everything `castor pair` produced — returned so callers/tests can assert."""
+
+    payload: dict
+    identity: AttestationIdentity
+    env_file: Path
+
+
+def default_gateway_url(port: int = 8080) -> str:
+    """Best-effort LAN URL for the gateway. Falls back to 127.0.0.1.
+
+    Uses the standard connect-a-UDP-socket trick to learn the primary LAN IP
+    without sending anything. The client scans this over the local network.
+    """
+    ip = "127.0.0.1"
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("192.0.2.1", 9))  # TEST-NET-1; no packets actually sent
+            ip = s.getsockname()[0]
+        finally:
+            s.close()
+    except OSError:
+        pass
+    return f"http://{ip}:{port}"
+
+
+def generate_attestation_identity(
+    key_file: Path, *, kid: str | None = None, force: bool = False
+) -> AttestationIdentity:
+    """Generate an Ed25519 attestation identity and persist it.
+
+    Reuses the gateway's own throwaway-key recipe (PKCS8 PEM, NoEncryption) so
+    the key the gateway loads is byte-compatible with
+    ``serialization.load_pem_private_key``. Writes ``<key_file>`` (0600) and a
+    sibling ``<key_file>.pub`` (0644, SubjectPublicKeyInfo PEM) for the operator
+    / app to resolve the kid to a public key.
+
+    kid defaults to ``gw-<sha256(raw pubkey)[:12]>`` — stable per key, unique.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    key_file = key_file.expanduser().resolve()
+    if key_file.exists() and not force:
+        raise FileExistsError(
+            f"{key_file} already exists; pass force=True (or --force) to overwrite "
+            "(this rotates the attestation identity)."
+        )
+
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    raw_pub = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    if kid is None:
+        kid = f"gw-{hashlib.sha256(raw_pub).hexdigest()[:12]}"
+
+    key_file.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_bytes(key_file, priv_pem, mode=0o600)
+    pub_file = key_file.with_suffix(key_file.suffix + ".pub")
+    _atomic_write_bytes(pub_file, pub_pem, mode=0o644)
+
+    return AttestationIdentity(key_file=key_file, kid=kid, pub_file=pub_file)
+
+
+def read_bearer_from_bearers_yaml(path: Path, *, prefer_tier: str = "actuate") -> str:
+    """Extract a bearer token from a robot-md-gateway bearers.yaml.
+
+    Prefers an entry whose ``tier`` is ``prefer_tier`` (default ``actuate`` — the
+    tier the app needs to drive the robot); falls back to the first token.
+    """
+    import yaml
+
+    data = yaml.safe_load(path.expanduser().read_text()) or []
+    if not isinstance(data, list):
+        raise ValueError(f"{path}: expected a list of bearer entries")
+    entries = [e for e in data if isinstance(e, dict) and e.get("token")]
+    if not entries:
+        raise ValueError(f"{path}: no bearer entries with a token found")
+    for entry in entries:
+        if entry.get("tier") == prefer_tier:
+            return str(entry["token"])
+    return str(entries[0]["token"])
+
+
+def read_rrn_from_manifest(manifest_path: Path) -> str:
+    """Parse the robot's RRN out of a ROBOT.md YAML frontmatter block.
+
+    Reads ``metadata.rrn`` (RCAN v3 shape), falling back to a top-level ``rrn``.
+    Returns "" when neither is present (the caller may then require --rrn).
+    """
+    import yaml
+
+    text = manifest_path.expanduser().read_text()
+    fm = _extract_frontmatter(text)
+    data = yaml.safe_load(fm) if fm else {}
+    if not isinstance(data, dict):
+        return ""
+    metadata = data.get("metadata") or {}
+    rrn = (metadata.get("rrn") if isinstance(metadata, dict) else None) or data.get("rrn")
+    return str(rrn) if rrn else ""
+
+
+def set_env_var(env_file: Path, key: str, value: str) -> None:
+    """Idempotently set ``key=value`` in a dotenv-style file, preserving others.
+
+    If ``key`` already appears it is replaced in place; otherwise it is appended.
+    All other lines (e.g. the gateway's ROBOT_MD_PATH / ROBOT_MD_BEARERS_FILE) are
+    left untouched, so pointing --env-file at the gateway's existing .env is safe.
+    """
+    env_file = env_file.expanduser()
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    lines = env_file.read_text().splitlines() if env_file.exists() else []
+    new_line = f"{key}={value}"
+    replaced = False
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and stripped.split("=", 1)[0] == key:
+            out.append(new_line)
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        out.append(new_line)
+    content = "\n".join(out) + "\n"
+    _atomic_write_bytes(env_file, content.encode("utf-8"), mode=0o644)
+
+
+def build_pair_payload(
+    *,
+    gateway_url: str,
+    bearer: str,
+    manifest_path: str,
+    rrn: str,
+    estop_url: str | None = None,
+) -> dict:
+    """Build the pairing QR payload. estop_url is included only when provided."""
+    payload = {
+        "v": PAIR_PAYLOAD_VERSION,
+        "gateway_url": gateway_url,
+        "bearer": bearer,
+        "manifest_path": manifest_path,
+        "rrn": rrn,
+    }
+    if estop_url:
+        payload["estop_url"] = estop_url
+    return payload
+
+
+def run_pair(
+    *,
+    manifest_path: Path,
+    gateway_url: str,
+    bearer: str,
+    rrn: str,
+    key_file: Path,
+    env_file: Path,
+    kid: str | None = None,
+    estop_url: str | None = None,
+    force: bool = False,
+) -> PairResult:
+    """Generate the identity, wire the env, and build the QR payload.
+
+    This is the testable core of ``castor pair`` — no printing, no argparse. The
+    manifest_path is resolved to an absolute gateway-host-local path before it is
+    placed in the QR (the client cannot guess it).
+    """
+    identity = generate_attestation_identity(key_file, kid=kid, force=force)
+
+    set_env_var(env_file, ATTESTATION_KEY_FILE_ENV, str(identity.key_file))
+    set_env_var(env_file, ATTESTATION_KID_ENV, identity.kid)
+
+    payload = build_pair_payload(
+        gateway_url=gateway_url,
+        bearer=bearer,
+        manifest_path=str(manifest_path.expanduser().resolve()),
+        rrn=rrn,
+        estop_url=estop_url,
+    )
+    return PairResult(payload=payload, identity=identity, env_file=env_file.expanduser())
+
+
+def _extract_frontmatter(text: str) -> str:
+    """Return the YAML frontmatter block (between the first two '---' fences)."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return ""
+    body: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return "\n".join(body)
+        body.append(line)
+    return ""
+
+
+def _atomic_write_bytes(path: Path, content: bytes, *, mode: int) -> None:
+    """Atomic write with an explicit permission mode (mirrors init_wizard)."""
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+        os.chmod(tmp_name, mode)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise

--- a/docs/claude/env-vars.md
+++ b/docs/claude/env-vars.md
@@ -9,7 +9,7 @@ Copy `.env.example` to `.env` and fill in what you need.
 | `GOOGLE_API_KEY` | Google Gemini | |
 | `OPENAI_API_KEY` | OpenAI GPT-4.1 | Also used for OpenRouter |
 | `ANTHROPIC_API_KEY` | Anthropic Claude | |
-| `OPENROUTER_API_KEY` | OpenRouter (100+ models) | `pip install opencastor` — same `openai` SDK, different base_url |
+| `OPENROUTER_API_KEY` | OpenRouter (100+ models) | `pip install "opencastor==3.*"` — same `openai` SDK, different base_url |
 | `GROQ_API_KEY` | Groq LPU inference | sub-100ms inference; `pip install groq` |
 | `MOONSHOT_API_KEY` | Kimi (Moonshot AI) | Chinese LLM |
 | `MINIMAX_API_KEY` | MiniMax | Chinese LLM |

--- a/docs/community/reddit-launch-post.md
+++ b/docs/community/reddit-launch-post.md
@@ -91,7 +91,7 @@ And you get a tested config for a PiCar-X home patrol bot. I've seeded 7 recipes
 **Quick start:**
 
 ```bash
-pip install opencastor
+pip install "opencastor==3.*"
 castor wizard   # interactive setup
 castor run --config my_robot.rcan.yaml
 ```

--- a/docs/embedding-interpreter.md
+++ b/docs/embedding-interpreter.md
@@ -40,7 +40,7 @@ Auto-tier selection walks from Tier 0 → Tier 1 → Tier 2 → mock. Install on
 ```bash
 pip install opencastor[clip]       # CLIP (recommended default)
 pip install opencastor[imagebind]  # ImageBind + CLAP (experimental)
-pip install opencastor             # Gemini Embedding 2 (uses existing google-genai dep)
+pip install "opencastor==3.*"     # Gemini Embedding 2 (uses existing google-genai dep)
 ```
 
 ### Tier 0 — CLIP / SigLIP2 (default)

--- a/docs/pypi-versioning.md
+++ b/docs/pypi-versioning.md
@@ -1,0 +1,92 @@
+# OpenCastor PyPI versioning & the CalVer trap
+
+**Status:** mitigated by pinning (shipped, credential-free); durable yank deferred
+to an operator with PyPI maintainer access.
+**Date:** 2026-07-16 · **Owner:** release operator
+
+## The trap
+
+OpenCastor shipped ~98 releases on a **CalVer** scheme (`YYYY.M.D.patch`, e.g.
+`2026.4.23.0`) before moving to **SemVer** on the `3.x` line (`3.0.0`, `3.0.1`,
+`3.0.2`). Under [PEP 440](https://peps.python.org/pep-0440/) the CalVer line sorts
+**above** the 3.x line:
+
+```
+Version("2026.4.23.0") > Version("3.0.2")   # True
+Version("2026.4.23.0") > Version("3.0.3")   # True  ← a NEW 3.0.3 still loses
+```
+
+So `pip install opencastor` (no pin) resolves the stale `2026.4.23.0`, and simply
+**publishing a higher 3.x number does not help** — every `2026.*` release outranks
+every `3.x` release. Confirmed against the live index on 2026-07-16:
+
+| Command (clean venv, `--no-deps`)            | Resolves to                          |
+|----------------------------------------------|--------------------------------------|
+| `pip download opencastor`                    | `opencastor-2026.4.23.0-py3-none-any.whl` ← **trap** |
+| `pip download "opencastor==3.*"`             | `opencastor-3.0.2-py3-none-any.whl`  ← correct |
+
+PyPI's own "latest" (`info.version` in the JSON API) is likewise `2026.4.23.0`.
+Totals: **101 releases; 98 CalVer; 3 on the 3.x line** (`3.0.0/3.0.1/3.0.2`).
+
+## Decision
+
+Two independent fixes; we apply BOTH.
+
+### 1. Pin everywhere — the sole supported install command (shipped now)
+
+The **only** supported install command is pinned to the 3.x line:
+
+```bash
+pip install "opencastor==3.*"
+```
+
+A bare `pip install opencastor` is **not supported** until the yank (below) lands —
+it resolves the retired CalVer line. Every install reference in this repo, the
+website, and the iOS app's Set-Up screen is pinned to `opencastor==3.*` (or an
+exact `opencastor==3.0.x`). This needs no PyPI credentials and takes effect
+immediately for anyone following the docs.
+
+### 2. Yank the 98 CalVer releases — the durable fix (operator, needs PyPI creds)
+
+Yanking ([PEP 592](https://peps.python.org/pep-0592/)) marks the CalVer releases so
+pip's resolver stops offering them for a bare/range requirement, while leaving them
+installable by exact pin (so nothing already pinned to a `2026.*` version breaks).
+After yanking all 98, a bare `pip install opencastor` resolves `3.0.2` — the highest
+non-yanked release — and the trap is gone for good.
+
+**Why this is deferred:** Warehouse (pypi.org) exposes **no** token-authenticated
+API for yanking — `twine` cannot yank. It is a maintainer **web-UI** action (2FA
+login), so it cannot run headless from CI or this workspace. The list and the
+procedure are prepared below; a human with maintainer access executes it.
+
+#### Operator procedure
+
+```bash
+# 1. Enumerate the versions and their per-release manage URLs:
+python scripts/pypi_yank_calver.py            # the 98 versions
+python scripts/pypi_yank_calver.py --urls     # https://pypi.org/manage/project/opencastor/release/<v>/
+
+# 2. For EACH version, on its manage page (logged in as a maintainer):
+#    Options -> Yank -> reason: "CalVer line superseded by 3.x SemVer;
+#    see docs/pypi-versioning.md" -> confirm.
+
+# 3. Verify a bare install now resolves 3.x:
+python scripts/pypi_yank_calver.py --verify
+# -> expect opencastor-3.0.2-* (NOT 2026.4.x)
+```
+
+The full 98-version list lives in `scripts/pypi_yank_calver.py` (`CALVER_VERSIONS`),
+generated from `https://pypi.org/pypi/opencastor/json`. Regenerate before yanking if
+more CalVer releases were cut in the interim.
+
+#### Do NOT
+
+- **Do not delete** the releases (deletion is irreversible and breaks exact pins;
+  yank is the reversible, PEP-592-correct action).
+- **Do not** cut another CalVer release. All future releases stay on SemVer `3.x+`.
+
+## After the yank
+
+Once yanked, the pin is still the recommended hygiene (reproducible installs), but a
+bare `pip install opencastor` will be safe again. Update the "Status" line at the top
+of this file to record the completion date and who performed it.

--- a/docs/setup/pairing.md
+++ b/docs/setup/pairing.md
@@ -1,0 +1,82 @@
+# Pairing your robot with the OpenCastor iOS app
+
+`castor pair` is the one command that connects the free OpenCastor iOS app to a
+robot running the [robot-md-gateway](https://github.com/RobotRegistryFoundation/robot-md-gateway).
+It prints a QR code you scan from the app, and — in the same step — generates the
+gateway's Ed25519 **attestation identity** so every `/v1/invoke` decision comes
+back as a signed, verifiable receipt.
+
+## Prerequisites
+
+1. A robot with a `ROBOT.md` manifest and the gateway installed:
+   ```bash
+   pip install "opencastor==3.*"          # the runtime (ships `castor pair`)
+   pip install robot-md-gateway            # the enforcement gateway
+   ```
+2. Bearer tokens for the gateway. Generate them once with the gateway wizard:
+   ```bash
+   robot-md-gateway init          # writes bearers.yaml (+ .env) next to ROBOT.md
+   ```
+
+## Run `castor pair`
+
+From the robot host:
+
+```bash
+castor pair \
+  --manifest-path /home/pi/ROBOT.md \
+  --bearers /home/pi/bearers.yaml \
+  --gateway-url http://robot.local:8080
+```
+
+`castor pair`:
+
+1. **Generates an Ed25519 attestation keypair** (throwaway PKCS8 PEM), writes the
+   private key to `~/.config/opencastor/attestation/gateway-attestation.pem`
+   (mode `0600`) and a public key alongside it.
+2. **Wires the gateway config** — writes
+   `ROBOT_MD_ATTESTATION_KEY_FILE` and `ROBOT_MD_ATTESTATION_KID` into
+   `~/.config/opencastor/gateway-attestation.env`. These are the exact variables
+   the gateway's attestation loader reads, so signed receipts turn on with no code
+   change.
+3. **Prints a scannable QR** encoding the pairing payload plus the decoded JSON.
+
+### The pairing QR payload
+
+```json
+{
+  "v": 1,
+  "gateway_url": "http://robot.local:8080",
+  "bearer": "actuate-token-abc",
+  "manifest_path": "/home/pi/ROBOT.md",
+  "rrn": "RRN-000000000011",
+  "estop_url": "http://robot.local:8001/api/stop"
+}
+```
+
+`manifest_path` **must** ride in the QR: it is a gateway-host-local filesystem
+path that every `InvokeEnvelope` requires and the phone cannot guess. `estop_url`
+is optional and only present if you pass `--estop-url`.
+
+## Start the gateway with attestation enabled
+
+`castor pair` prints these lines — run them to (re)start the gateway with the
+attestation identity it just created:
+
+```bash
+set -a; . ~/.config/opencastor/gateway-attestation.env; set +a
+robot-md-gateway serve \
+  --robot-md /home/pi/ROBOT.md \
+  --bearers /home/pi/bearers.yaml \
+  --host 0.0.0.0 --port 8080
+```
+
+Now scan the QR from the app's **Set Up** screen. The first `/v1/invoke` returns a
+signed receipt (`envelope_signature: {kid, alg, sig}`) the app verifies offline.
+
+## Notes
+
+- The install command is pinned (`opencastor==3.*`). A bare `pip install opencastor`
+  can resolve a stale CalVer release — see [pypi-versioning](../pypi-versioning.md).
+- Re-running `castor pair` refuses to overwrite an existing key unless you pass
+  `--force` (which rotates the attestation identity).

--- a/scripts/pypi_yank_calver.py
+++ b/scripts/pypi_yank_calver.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Operator helper for the OpenCastor PyPI CalVer remediation (T-003).
+
+PROBLEM
+    `pip install opencastor` resolves the stale CalVer line (e.g. 2026.4.23.0)
+    ABOVE the maintained 3.x line, because PEP 440 sorts
+        Version("2026.4.23.0") > Version("3.0.3")
+    A brand-new 3.0.3 STILL sorts below every 2026.* release, so bumping the
+    version does not fix it. The durable fix is to YANK the 98 CalVer releases so
+    PyPI's resolver stops offering them for a bare/range requirement.
+
+WHAT YANK DOES (and does not)
+    Yanking (PEP 592) marks a release so pip will NOT select it for a bare or
+    range spec (`opencastor`, `opencastor>=3`), but it is NOT a delete — a build
+    that pins the EXACT version (`opencastor==2026.4.23.0`) can still install it,
+    so nothing already pinned breaks. After yanking all 98 CalVer releases, a bare
+    `pip install opencastor` resolves 3.0.2 (the highest non-yanked release).
+
+HOW TO YANK
+    Warehouse (pypi.org) exposes NO token-authenticated REST endpoint for yank —
+    twine cannot yank. Yanking is a maintainer web-UI action (2FA login required):
+        https://pypi.org/manage/project/opencastor/release/<version>/
+        -> "Options" -> "Yank" -> enter a reason (e.g. "CalVer line superseded by
+           3.x SemVer; see docs/pypi-versioning.md") -> confirm.
+
+USAGE
+    python scripts/pypi_yank_calver.py            # list the 98 versions
+    python scripts/pypi_yank_calver.py --urls     # print the manage/yank URL per version
+    python scripts/pypi_yank_calver.py --verify   # print the post-yank verification command
+
+This script deliberately performs NO network writes: yanking is operator-gated
+(needs the PyPI maintainer session). It only enumerates the work.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+PROJECT = "opencastor"
+
+# The 98 stale CalVer (YYYY.M.D.patch) releases to yank, oldest -> newest.
+# Generated from https://pypi.org/pypi/opencastor/json (2026-07-16). The three
+# maintained SemVer releases 3.0.0 / 3.0.1 / 3.0.2 are intentionally NOT listed.
+CALVER_VERSIONS = [
+    "2026.2.17.3", "2026.2.17.6", "2026.2.17.7", "2026.2.17.8", "2026.2.17.10", "2026.2.17.11",
+    "2026.2.17.12", "2026.2.17.13", "2026.2.17.14", "2026.2.17.15", "2026.2.17.16",
+    "2026.2.17.17", "2026.2.17.18", "2026.2.17.19", "2026.2.17.20", "2026.2.17.21",
+    "2026.2.18.3", "2026.2.18.4", "2026.2.18.5", "2026.2.18.6", "2026.2.18.7", "2026.2.18.8",
+    "2026.2.18.9", "2026.2.18.10", "2026.2.18.11", "2026.2.18.12", "2026.2.18.13",
+    "2026.2.19.0", "2026.2.19.1", "2026.2.20.0", "2026.2.20.1", "2026.2.20.2", "2026.2.20.5",
+    "2026.2.20.6", "2026.2.20.7", "2026.2.20.8", "2026.2.20.9", "2026.2.20.10", "2026.2.23.5",
+    "2026.2.23.6", "2026.2.23.7", "2026.2.23.8", "2026.2.23.9", "2026.2.23.10", "2026.2.23.11",
+    "2026.2.23.12", "2026.2.23.13", "2026.2.26.1", "2026.2.26.2", "2026.2.27.2", "2026.3.1.14",
+    "2026.3.1.15", "2026.3.1.16", "2026.3.3.0", "2026.3.7.0", "2026.3.8.0", "2026.3.8.3",
+    "2026.3.12.0", "2026.3.12.3", "2026.3.12.4", "2026.3.12.5", "2026.3.12.7", "2026.3.12.8",
+    "2026.3.13.0", "2026.3.13.1", "2026.3.13.2", "2026.3.13.3", "2026.3.13.4", "2026.3.13.5",
+    "2026.3.13.6", "2026.3.13.7", "2026.3.13.8", "2026.3.13.9", "2026.3.13.10", "2026.3.13.11",
+    "2026.3.13.12", "2026.3.13.13", "2026.3.13.14", "2026.3.14.0", "2026.3.14.1",
+    "2026.3.14.2", "2026.3.14.6", "2026.3.17.13", "2026.3.20.3", "2026.3.20.4", "2026.3.21.1",
+    "2026.3.21.2", "2026.3.27.1", "2026.3.28.0", "2026.3.29.0", "2026.3.29.1", "2026.3.30.0",
+    "2026.4.1.0", "2026.4.2.0", "2026.4.3.0", "2026.4.12.0", "2026.4.15.0", "2026.4.23.0",
+]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--urls", action="store_true", help="Print the manage/yank URL for each version")
+    ap.add_argument("--verify", action="store_true", help="Print the post-yank verification command")
+    args = ap.parse_args()
+
+    if args.verify:
+        print("# After yanking all versions below, confirm a bare install resolves 3.x:")
+        print("python -m venv /tmp/ocverify && /tmp/ocverify/bin/pip install --upgrade pip")
+        print(f"/tmp/ocverify/bin/pip download {PROJECT} --no-deps -d /tmp/ocverify/dl")
+        print("ls /tmp/ocverify/dl   # expect opencastor-3.0.2-* (NOT 2026.4.x)")
+        return
+
+    print(f"# {len(CALVER_VERSIONS)} CalVer releases to yank for '{PROJECT}':")
+    for v in CALVER_VERSIONS:
+        if args.urls:
+            print(f"https://pypi.org/manage/project/{PROJECT}/release/{v}/")
+        else:
+            print(v)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,129 @@
+"""T-002 — castor pair: QR payload shape + gateway attestation wiring.
+
+Asserts the pairing core (castor.pairing) produces the exact QR payload the iOS
+app parses and writes the exact env vars the robot-md-gateway attestation loader
+reads (ROBOT_MD_ATTESTATION_KEY_FILE + ROBOT_MD_ATTESTATION_KID).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from castor import pairing
+
+MANIFEST = """---
+rcan_version: "3.2"
+metadata:
+  robot_name: bob
+  rrn: RRN-000000000011
+---
+
+# Bob
+
+A test robot manifest.
+"""
+
+
+@pytest.fixture
+def manifest(tmp_path: Path) -> Path:
+    p = tmp_path / "ROBOT.md"
+    p.write_text(MANIFEST)
+    return p
+
+
+def _run(tmp_path: Path, manifest: Path, **overrides) -> pairing.PairResult:
+    kwargs = dict(
+        manifest_path=manifest,
+        gateway_url="http://192.168.1.50:8080",
+        bearer="tok-actuate",
+        rrn="RRN-000000000011",
+        key_file=tmp_path / "attn" / "gw.pem",
+        env_file=tmp_path / "gw.env",
+    )
+    kwargs.update(overrides)
+    return pairing.run_pair(**kwargs)
+
+
+def test_qr_payload_has_the_five_required_keys(tmp_path, manifest):
+    result = _run(tmp_path, manifest)
+    payload = result.payload
+    assert set(payload) >= {"v", "gateway_url", "bearer", "manifest_path", "rrn"}
+    assert payload["v"] == 1
+    assert payload["gateway_url"] == "http://192.168.1.50:8080"
+    assert payload["bearer"] == "tok-actuate"
+    assert payload["rrn"] == "RRN-000000000011"
+    # manifest_path rides in the QR as an absolute gateway-host-local path.
+    assert payload["manifest_path"] == str(manifest.resolve())
+    assert Path(payload["manifest_path"]).is_absolute()
+
+
+def test_estop_url_included_only_when_provided(tmp_path, manifest):
+    without = _run(tmp_path, manifest)
+    assert "estop_url" not in without.payload
+
+    with_estop = _run(
+        tmp_path,
+        manifest,
+        key_file=tmp_path / "attn2" / "gw.pem",
+        env_file=tmp_path / "gw2.env",
+        estop_url="http://192.168.1.50:8001/api/stop",
+    )
+    assert with_estop.payload["estop_url"] == "http://192.168.1.50:8001/api/stop"
+
+
+def test_attestation_keypair_written_and_loadable(tmp_path, manifest):
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    result = _run(tmp_path, manifest)
+    key_file = result.identity.key_file
+    assert key_file.exists()
+    # The gateway loads this via load_pem_private_key — must be an Ed25519 PKCS8 PEM.
+    priv = load_pem_private_key(key_file.read_bytes(), password=None)
+    assert isinstance(priv, Ed25519PrivateKey)
+    # A sibling public key PEM is written for kid resolution.
+    assert result.identity.pub_file.exists()
+    assert result.identity.kid.startswith("gw-")
+    # Private key is not world-readable.
+    assert (key_file.stat().st_mode & 0o077) == 0
+
+
+def test_env_file_sets_exact_gateway_attestation_vars(tmp_path, manifest):
+    result = _run(tmp_path, manifest)
+    env_text = result.env_file.read_text()
+    # The exact vars robot_md_gateway.attestation.load_signing_identity_from_env reads.
+    assert f"{pairing.ATTESTATION_KEY_FILE_ENV}={result.identity.key_file}" in env_text
+    assert f"{pairing.ATTESTATION_KID_ENV}={result.identity.kid}" in env_text
+
+
+def test_set_env_var_preserves_and_updates(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("ROBOT_MD_PATH=./ROBOT.md\nROBOT_MD_BEARERS_FILE=./bearers.yaml\n")
+    pairing.set_env_var(env, pairing.ATTESTATION_KID_ENV, "gw-abc")
+    pairing.set_env_var(env, pairing.ATTESTATION_KID_ENV, "gw-def")  # idempotent replace
+    text = env.read_text()
+    assert "ROBOT_MD_PATH=./ROBOT.md" in text  # untouched
+    assert "ROBOT_MD_BEARERS_FILE=./bearers.yaml" in text  # untouched
+    assert text.count("ROBOT_MD_ATTESTATION_KID=") == 1  # replaced in place, not duplicated
+    assert "ROBOT_MD_ATTESTATION_KID=gw-def" in text
+
+
+def test_rrn_parsed_from_manifest_frontmatter(manifest):
+    assert pairing.read_rrn_from_manifest(manifest) == "RRN-000000000011"
+
+
+def test_bearer_read_prefers_actuate_tier(tmp_path):
+    bearers = tmp_path / "bearers.yaml"
+    bearers.write_text(
+        "- token: read-tok\n  tier: read\n"
+        "- token: actuate-tok\n  tier: actuate\n"
+    )
+    assert pairing.read_bearer_from_bearers_yaml(bearers) == "actuate-tok"
+
+
+def test_existing_key_not_clobbered_without_force(tmp_path, manifest):
+    _run(tmp_path, manifest)
+    with pytest.raises(FileExistsError):
+        _run(tmp_path, manifest)  # same key_file, force defaults False

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -194,7 +194,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           </a>
           <a href="https://pypi.org/project/opencastor/" class="link-card reveal reveal-d1">
             <h4>🐍 PyPI</h4>
-            <p>pip install opencastor</p>
+            <p>pip install "opencastor==3.*"</p>
           </a>
           <a href="https://rcan.dev/spec/" class="link-card reveal reveal-d2">
             <h4>📄 RCAN Spec</h4>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -33,7 +33,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
             <div class="code-header">
               <div class="code-dots"><span></span><span></span><span></span></div><span class="code-filename">pip (all platforms)</span>
             </div>
-            <div class="code-body">pip install opencastor</div>
+            <div class="code-body">pip install "opencastor==3.*"</div>
           </div>
           <div class="code-block" style="margin-bottom:12px">
             <div class="code-header">


### PR DESCRIPTION
Two changes supporting the OpenCastor on-ramp, verified locally on a Pi (nothing auto-deployed).

## `castor pair` (T-002)
New pairing command (`castor/pairing.py` + `castor/cli.py`) that prints a scannable QR encoding `{v:1, gateway_url, bearer, manifest_path, rrn, estop_url?}` — `manifest_path` rides in the QR because the gateway's `InvokeEnvelope` requires the gateway-host-local path, which a client can't guess. The command also generates an Ed25519 attestation identity and writes `ROBOT_MD_ATTESTATION_KEY_FILE`/`KID`, so a paired gateway returns **signed** receipts (ties to robot-md-gateway signed-receipt PR). `tests/test_pairing.py`: 8 passed. Pairing walkthrough in `docs/setup/pairing.md`.

## Fix the PyPI CalVer install trap (T-003)
Under PEP 440, `2026.4.23.0 > 3.0.2`, so a bare `pip install opencastor` resolves the stale CalVer line instead of the current 3.x. This pins **`opencastor==3.*`** as the sole documented install across the site and docs, and adds `docs/pypi-versioning.md` recording the decision plus `scripts/pypi_yank_calver.py` (the 98 CalVer versions to yank).

Follow-up (operator, credential-gated — Warehouse yank is web-UI + 2FA only): run `scripts/pypi_yank_calver.py` for the manage URLs and yank `2026.2.17.3` … `2026.4.23.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)